### PR TITLE
Sign and format images

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,13 @@
   },
   "dependencies": {
     "@guardian/src-foundations": "^0.2.3",
+    "@types/md5": "^2.1.33",
     "aws-sdk": "^2.554.0",
     "compression": "^1.7.4",
     "emotion": "^10.0.17",
     "emotion-server": "^10.0.17",
     "express": "^4.17.1",
+    "md5": "^2.2.1",
     "react": "^16.11.0",
     "react-dom": "^16.11.0"
   }

--- a/src/email.tsx
+++ b/src/email.tsx
@@ -8,6 +8,7 @@ import { css } from "./css";
 import { Padding } from "./layout/Padding";
 import { Heading } from "./components/Heading";
 import { Multiline } from "./components/Multiline";
+import { formatImage } from './image';
 
 const canonicalURL = (path: string): string =>
     `https://www.theguardian.com/${path}`;
@@ -28,7 +29,7 @@ const title = (id: string): string => {
     );
 };
 
-export const Email = (front: Front) => {
+export const Email = (front: Front, salt: string) => {
     const collection = front.collections[0];
 
     const body = renderToStaticMarkup(
@@ -43,10 +44,12 @@ export const Email = (front: Front) => {
                 const image =
                     content.properties.maybeContent.trail.trailPicture
                         .allImages[0];
+                const formattedImage = formatImage(image.url, salt);
+
                 return (
                     <>
                         <Card
-                            imageURL={image.url}
+                            imageURL={formattedImage}
                             imageAlt={image.fields.altText}
                             headline={content.properties.webTitle}
                             byline={content.properties.byline}

--- a/src/image.test.ts
+++ b/src/image.test.ts
@@ -1,0 +1,42 @@
+import { formatImage, sign, source } from "./image";
+
+test("images are signed correctly", () => {
+    const testURLs = [
+        'http://media.guim.co.uk/67222cbde87dc147dd34041c2e8692b81f24f546/0_0_1204_1181/500.jpg?width=300&quality=50&height=100',
+    ];
+
+    const salt = "haha";
+
+    testURLs.forEach(url => {
+        const asURL = new URL(url);
+        const got = sign(asURL.pathname + asURL.search, salt);
+        const want = "c0b3e8200cdc0f0c1140b08a5f7849a0";
+        expect(got).toEqual(want);
+    });
+});
+
+test("extract image source", () => {
+    const cases = [
+        ["//uploads.guim.co.uk", "uploads"],
+        ["//lol.guim.co.uk", "media"],
+    ];
+
+    cases.forEach(testCase => {
+        const got = source(testCase[0]);
+        const want = testCase[1];
+        expect(got).toEqual(want);
+    });
+});
+
+test("formats full URL", () => {
+    const testURLs = [
+        'http://media.guim.co.uk/67222cbde87dc147dd34041c2e8692b81f24f546/0_0_1204_1181/500.jpg',
+    ];
+
+    testURLs.forEach(url => {
+        const got = formatImage(url, "foo");
+        const want = "https://i.guim.co.uk/img/media/67222cbde87dc147dd34041c2e8692b81f24f546/0_0_1204_1181/500.jpg?quality=45&sharpen=a0.8,r1,t1&width=600&dpr=2&fit=max&s=e6f7cfcca297387ce8efb4ce5164f822";
+        expect(got).toEqual(want);
+    });
+
+});

--- a/src/image.test.ts
+++ b/src/image.test.ts
@@ -1,8 +1,9 @@
+import { URL } from "url";
 import { formatImage, sign, source } from "./image";
 
 test("images are signed correctly", () => {
     const testURLs = [
-        'http://media.guim.co.uk/67222cbde87dc147dd34041c2e8692b81f24f546/0_0_1204_1181/500.jpg?width=300&quality=50&height=100',
+        "http://media.guim.co.uk/67222cbde87dc147dd34041c2e8692b81f24f546/0_0_1204_1181/500.jpg?width=300&quality=50&height=100"
     ];
 
     const salt = "haha";
@@ -18,7 +19,7 @@ test("images are signed correctly", () => {
 test("extract image source", () => {
     const cases = [
         ["//uploads.guim.co.uk", "uploads"],
-        ["//lol.guim.co.uk", "media"],
+        ["//lol.guim.co.uk", "media"]
     ];
 
     cases.forEach(testCase => {
@@ -30,13 +31,13 @@ test("extract image source", () => {
 
 test("formats full URL", () => {
     const testURLs = [
-        'http://media.guim.co.uk/67222cbde87dc147dd34041c2e8692b81f24f546/0_0_1204_1181/500.jpg',
+        "http://media.guim.co.uk/67222cbde87dc147dd34041c2e8692b81f24f546/0_0_1204_1181/500.jpg"
     ];
 
     testURLs.forEach(url => {
         const got = formatImage(url, "foo");
-        const want = "https://i.guim.co.uk/img/media/67222cbde87dc147dd34041c2e8692b81f24f546/0_0_1204_1181/500.jpg?quality=45&sharpen=a0.8,r1,t1&width=600&dpr=2&fit=max&s=e6f7cfcca297387ce8efb4ce5164f822";
+        const want =
+            "https://i.guim.co.uk/img/media/67222cbde87dc147dd34041c2e8692b81f24f546/0_0_1204_1181/500.jpg?quality=45&sharpen=a0.8,r1,t1&width=600&dpr=2&fit=max&s=e6f7cfcca297387ce8efb4ce5164f822";
         expect(got).toEqual(want);
     });
-
 });

--- a/src/image.ts
+++ b/src/image.ts
@@ -1,0 +1,44 @@
+import md5 from 'md5';
+
+const fastlyURL = "https://i.guim.co.uk/img/";
+
+export const sign = (s: string, salt: string): string => {
+    return md5(salt + s);
+}
+
+export const source = (guimURL: string): string => {
+    const re = /(media|static|uploads|sport).guim.co.uk/;
+    const found = guimURL.match(re);
+
+    if (found) {
+        return found[1]; // capture group
+    }
+
+    return "media";
+};
+
+// See:
+// https://github.com/guardian/frontend/blob/master/common/app/views/support/ImageProfile.scala#L242
+export const formatImage = (masterURL: string, salt: string): string => {
+
+    // https://docs.fastly.com/api/imageopto/
+    const params = {
+        quality: "45",
+        sharpen: "a0.8,r1,t1",
+        width: "600",
+        dpr: "2",
+        fit: "max", // Note, this value looks invalid
+    };
+
+    const qs = Object.entries(params)
+        .map(kv => `${kv[0]}=${kv[1]}`)
+        .join("&");
+
+    const url = new URL(masterURL);
+    const pathQuery = url.pathname + "?" + qs;
+    const src = source(masterURL);
+    const sig = sign(pathQuery, salt);
+    const updatedPathQuery = pathQuery + '&s=' + sig;
+
+    return fastlyURL + src + updatedPathQuery;
+}

--- a/src/image.ts
+++ b/src/image.ts
@@ -1,10 +1,11 @@
-import md5 from 'md5';
+import md5 from "md5";
+import { URL } from "url";
 
 const fastlyURL = "https://i.guim.co.uk/img/";
 
 export const sign = (s: string, salt: string): string => {
     return md5(salt + s);
-}
+};
 
 export const source = (guimURL: string): string => {
     const re = /(media|static|uploads|sport).guim.co.uk/;
@@ -20,14 +21,13 @@ export const source = (guimURL: string): string => {
 // See:
 // https://github.com/guardian/frontend/blob/master/common/app/views/support/ImageProfile.scala#L242
 export const formatImage = (masterURL: string, salt: string): string => {
-
     // https://docs.fastly.com/api/imageopto/
     const params = {
         quality: "45",
         sharpen: "a0.8,r1,t1",
         width: "600",
         dpr: "2",
-        fit: "max", // Note, this value looks invalid
+        fit: "max" // Note, this value looks invalid
     };
 
     const qs = Object.entries(params)
@@ -38,7 +38,7 @@ export const formatImage = (masterURL: string, salt: string): string => {
     const pathQuery = url.pathname + "?" + qs;
     const src = source(masterURL);
     const sig = sign(pathQuery, salt);
-    const updatedPathQuery = pathQuery + '&s=' + sig;
+    const updatedPathQuery = pathQuery + "&s=" + sig;
 
     return fastlyURL + src + updatedPathQuery;
-}
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,11 @@ const app = express();
 app.use(express.json({ limit: "50mb" }));
 app.use(compression());
 
+const salt = process.env.IMAGE_SALT;
+if (!salt) {
+    throw new Error("Required IMAGE_SALT env var is empty");
+}
+
 app.get("/:path", async (req, res) => {
     try {
         const path = req.params.path;
@@ -19,7 +24,7 @@ app.get("/:path", async (req, res) => {
             return;
         }
 
-        res.send(Email(front).html);
+        res.send(Email(front, salt).html);
     } catch (e) {
         res.status(500).send({ error: e.stack });
     }

--- a/src/styles/typography.test.ts
+++ b/src/styles/typography.test.ts
@@ -7,6 +7,7 @@ test("typography", () => {
             "GuardianTextSans, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif",
         fontSize: "12px",
         lineHeight: "1.45em",
+        fontWeight: 400
     };
 
     expect(got).toEqual(want);

--- a/yarn.lock
+++ b/yarn.lock
@@ -472,6 +472,13 @@
   dependencies:
     "@types/jest-diff" "*"
 
+"@types/md5@^2.1.33":
+  version "2.1.33"
+  resolved "https://registry.yarnpkg.com/@types/md5/-/md5-2.1.33.tgz#8c8dba30df4ad0e92296424f08c4898dd808e8df"
+  integrity sha512-8+X960EtKLoSblhauxLKy3zzotagjoj3Jt1Tx9oaxUdZEPIBl+mkrUz6PNKpzJgkrKSN9YgkWTA29c0KnLshmA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/mime@*":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.1.tgz#dc488842312a7f075149312905b5e3c0b054c79d"
@@ -1031,6 +1038,11 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+charenc@~0.0.1:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+  integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
+
 chownr@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.3.tgz#42d837d5239688d55f303003a508230fa6727142"
@@ -1216,6 +1228,11 @@ cross-spawn@^6.0.0:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+crypt@~0.0.1:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
+  integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
 
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.8"
@@ -2098,7 +2115,7 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
-is-buffer@^1.1.5:
+is-buffer@^1.1.5, is-buffer@~1.1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -2916,6 +2933,15 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
+
+md5@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/md5/-/md5-2.2.1.tgz#53ab38d5fe3c8891ba465329ea23fac0540126f9"
+  integrity sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=
+  dependencies:
+    charenc "~0.0.1"
+    crypt "~0.0.1"
+    is-buffer "~1.1.1"
 
 media-typer@0.3.0:
   version "0.3.0"


### PR DESCRIPTION
*Note, at the moment this will error on startup if you haven't set an IMAGE_SALT env var. It feels like we should load this from config instead based on credentials to improve dev ex but that will be later/separate PR.*

Use CDN for caching, format and sign images.

See https://docs.fastly.com/api/imageopto/ for Fastly image formatting options.

The signing process is essentially md5 of the path+query string with an added salt.