### PR TITLE
Background color fix for footer section in Lotus Notes 8.5

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -11,7 +11,6 @@ const tableStyle: TableCSS = {
 const tableWrapper: TableCSS = {
     borderSpacing: 0,
     borderCollapse: "collapse",
-    backgroundColor: palette.neutral[20],
     backgroundRepeat: "no-repeat",
     backgroundPosition: "bottom right",
     backgroundImage: "url(https://assets.guim.co.uk/images/email/f189dff5bfa4dc66d092f57e973a51b9/grey-g.png)",
@@ -50,7 +49,7 @@ export const Footer: React.FC<{}> = () => (
     <table style={tableStyle}>
         <tr>
             <td style={tdPadding}>
-                <table style={tableWrapper}>
+                <table bgcolor={palette.neutral[20]} style={tableWrapper}>
                     <tr>
                         <td style={tdInnerPadding}>
                             <table style={tableStyle}>


### PR DESCRIPTION
Setting a background color as an attribute bgcolor on table fixes the issue with missing background-color on Lotus Notes 8.5

![Screen Shot 2019-11-04 at 16 58 01](https://user-images.githubusercontent.com/47107438/68140825-5b77e380-ff24-11e9-844f-aa05a87c35f2.png)
