### PR TITLE
Deprecated center tag removed.

### DIFF
--- a/src/layout/Center.tsx
+++ b/src/layout/Center.tsx
@@ -2,13 +2,19 @@ import React from "react";
 import { TableCSS } from "../css";
 import { palette } from "@guardian/src-foundations";
 
-const tableStyle: TableCSS = {
+const mainTableStyle: TableCSS = {
     borderSpacing: 0,
     borderCollapse: "collapse",
     background: palette.neutral[100],
     height: "100%",
     width: "100%",
 };
+
+const tableStyle: TableCSS = {
+    borderSpacing: 0,
+    borderCollapse: "collapse",
+    width: "100%"
+}
 
 const innerTableStyle: TableCSS = {
     borderSpacing: 0,
@@ -24,22 +30,26 @@ const containerTableStyle: TableCSS = {
 export const Center: React.FC<{ children: React.ReactNode }> = ({
     children
 }) => (
-    <table className="gwfw" style={tableStyle}>
+    <table style={mainTableStyle}>
         <tr>
             <td align="center" valign="top">
-                <center className="center-element" style={{ width: "100%" }}>
-                    <table style={innerTableStyle}>
-                        <tr>
-                            <td style={{ width: "600px" }}>
-                                <table align="center" className="container" style={containerTableStyle}>
-                                    <tr>
-                                        <td>{children}</td>
-                                    </tr>
-                                </table>
-                            </td>
-                        </tr>
-                    </table>
-                </center>
+                <table className="center-element" style={tableStyle}>
+                    <tr>
+                        <td align="center" valign="top">
+                            <table style={innerTableStyle}>
+                                <tr>
+                                    <td style={{ width: "600px" }}>
+                                        <table align="center" className="container" style={containerTableStyle}>
+                                            <tr>
+                                                <td>{children}</td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                </table>
             </td>
         </tr>
     </table>


### PR DESCRIPTION
Deprecated center tag has been removed and replaced with a table > tr > and td aligned center.