### PR TITLE
Braze parameter added in and footer links updated

### DIFF
--- a/src/components/Collection.tsx
+++ b/src/components/Collection.tsx
@@ -12,6 +12,7 @@ export const Collection: React.FC<{
         const image =
             content.properties.maybeContent.trail.trailPicture.allImages[0];
         const formattedImage = formatImage(image.url, salt);
+        const brazeParameter = "/##braze_utm##";
 
         return (
             <>
@@ -20,7 +21,7 @@ export const Collection: React.FC<{
                     imageAlt={image.fields.altText}
                     headline={content.properties.webTitle}
                     byline={content.properties.byline}
-                    webURL={content.properties.webUrl}
+                    webURL={content.properties.webUrl + brazeParameter}
                     key={content.properties.webUrl}
                 />
                 <Padding px={10} />

--- a/src/components/Collection.tsx
+++ b/src/components/Collection.tsx
@@ -12,7 +12,7 @@ export const Collection: React.FC<{
         const image =
             content.properties.maybeContent.trail.trailPicture.allImages[0];
         const formattedImage = formatImage(image.url, salt);
-        const brazeParameter = "/##braze_utm##";
+        const brazeParameter = "?##braze_utm##";
 
         return (
             <>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -58,7 +58,7 @@ export const Footer: React.FC<{}> = () => (
                             <table style={tableStyle}>
                                 <tr>
                                     <td className="ft__links" style={tdStyle}>
-                                        <a href="#" style={linkStyle}>Manage your emails</a> | <a href="#" style={linkStyle}>Unsubscribe</a> | <a href="#" style={linkStyle}>Trouble viewing?</a>
+                                        <a href="https://profile.theguardian.com/email-prefs?##braze_utm##" style={linkStyle}>Manage your emails</a> | <a href="%%unsub_center_url%%" style={linkStyle}>Unsubscribe</a> | <a href="https://www.theguardian.com/email/film-today?##braze_utm##" style={linkStyle}>Trouble viewing?</a>
                                     </td>
                                 </tr>
                                 <tr>

--- a/src/email.tsx
+++ b/src/email.tsx
@@ -57,7 +57,7 @@ export const Email = (front: Front, salt: string) => {
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta name="viewport" content="width=device-width" />
         <meta name="robots" content="noindex" />
-        <link rel="canonical" href=${canonicalURL(front.id)} />
+        <link rel="canonical" href="${canonicalURL(front.id)}" />
         <link rel="icon" href="https://static.guim.co.uk/images/${favicon}">
         <title>${title(front.id)}</title>
         <!--[if mso]>


### PR DESCRIPTION
Please note that currently link to a "Trouble viewing?" in the footer is linking to a current live preview of the email and this will have to be updated to a new endpoint before we send the Live test.