### PR TITLE
Add basic kicker support

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -73,9 +73,23 @@ interface Card {
     starRating?: number;
 }
 
+export interface Kicker {
+    type: string;
+    item: {
+        properties: {
+            kickerText?: string;
+        };
+    };
+}
+
+interface Header {
+    kicker?: Kicker;
+}
+
 interface Content {
     properties: Properties;
     card: Card;
+    header: Header;
 }
 
 export interface Collection {

--- a/src/api.ts
+++ b/src/api.ts
@@ -84,6 +84,7 @@ export interface Kicker {
 
 interface Header {
     kicker?: Kicker;
+    isComment: boolean;
 }
 
 interface Content {

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -57,6 +57,11 @@ const bottomPaddingStyle: TdCSS = {
     paddingBottom: "20px"
 };
 
+const quoteIconStyle: ImageCSS = {
+    height: "0.8em",
+    display: "inline-block"
+};
+
 interface Props {
     headline: string;
     byline: string;
@@ -64,6 +69,7 @@ interface Props {
     imageURL?: string;
     imageAlt?: string;
     kicker?: string;
+    isComment: boolean;
 }
 
 export const Card: React.FC<Props> = ({
@@ -72,7 +78,8 @@ export const Card: React.FC<Props> = ({
     webURL,
     imageURL,
     imageAlt,
-    kicker
+    kicker,
+    isComment
 }) => (
     <table style={tableStyle}>
         <tr>
@@ -105,6 +112,16 @@ export const Card: React.FC<Props> = ({
                                     </span>
                                 )}
                                 <span className="h-small" style={headlineStyle}>
+                                    {isComment && (
+                                        <>
+                                            <img
+                                                style={quoteIconStyle}
+                                                src="https://assets.guim.co.uk/images/email/icons/9682728db696148fd5a6b149e556df8c/quote-culture.png"
+                                                alt="quote icon"
+                                            />{" "}
+                                        </>
+                                    )}
+
                                     {headline}
                                 </span>
                                 <br className="m-hide" />

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -39,6 +39,12 @@ const headlineStyle: FontCSS = {
     fontWeight: 400
 };
 
+const kickerStyle: FontCSS = {
+    ...headlineStyle,
+
+    color: palette.culture.main
+};
+
 const bylineStyle: FontCSS = {
     color: palette.culture.main,
     fontFamily: "'Guardian Egyptian Web Headline Italic', Georgia, serif",
@@ -57,6 +63,7 @@ interface Props {
     webURL: string;
     imageURL?: string;
     imageAlt?: string;
+    kicker?: string;
 }
 
 export const Card: React.FC<Props> = ({
@@ -64,7 +71,8 @@ export const Card: React.FC<Props> = ({
     byline,
     webURL,
     imageURL,
-    imageAlt
+    imageAlt,
+    kicker
 }) => (
     <table style={tableStyle}>
         <tr>
@@ -88,6 +96,14 @@ export const Card: React.FC<Props> = ({
                     <tr>
                         <td className="h-pad" style={metaWrapperStyle}>
                             <a style={linkStyle} href={webURL}>
+                                {kicker && (
+                                    <span
+                                        className="h-small"
+                                        style={kickerStyle}
+                                    >
+                                        {kicker + " / "}
+                                    </span>
+                                )}
                                 <span className="h-small" style={headlineStyle}>
                                     {headline}
                                 </span>

--- a/src/components/Collection.tsx
+++ b/src/components/Collection.tsx
@@ -28,6 +28,7 @@ export const Collection: React.FC<{
                     webURL={content.properties.webUrl + brazeParameter}
                     key={content.properties.webUrl}
                     kicker={kicker}
+                    isComment={content.header.isComment}
                 />
                 <Padding px={10} />
             </>

--- a/src/components/Collection.tsx
+++ b/src/components/Collection.tsx
@@ -3,6 +3,7 @@ import { Collection as ICollection } from "../api";
 import { formatImage } from "../image";
 import { Padding } from "../layout/Padding";
 import { Card } from "./Card";
+import { kickerText } from "../kicker";
 
 export const Collection: React.FC<{
     collection: ICollection;
@@ -13,6 +14,9 @@ export const Collection: React.FC<{
             content.properties.maybeContent.trail.trailPicture.allImages[0];
         const formattedImage = formatImage(image.url, salt);
         const brazeParameter = "?##braze_utm##";
+        const kicker = content.header.kicker
+            ? kickerText(content.header.kicker)
+            : "";
 
         return (
             <>
@@ -23,6 +27,7 @@ export const Collection: React.FC<{
                     byline={content.properties.byline}
                     webURL={content.properties.webUrl + brazeParameter}
                     key={content.properties.webUrl}
+                    kicker={kicker}
                 />
                 <Padding px={10} />
             </>

--- a/src/css.ts
+++ b/src/css.ts
@@ -47,6 +47,7 @@ export interface ImageCSS {
     maxWidth?: string;
     clear?: "both";
     border?: string;
+    height?: string;
 }
 
 export interface LinkCSS extends FontCSS {

--- a/src/kicker.ts
+++ b/src/kicker.ts
@@ -1,0 +1,13 @@
+import { Kicker } from "./api";
+
+export const kickerText = (kicker: Kicker): string => {
+    // TODO implement other kicker types - see
+    // https://github.com/guardian/frontend/blob/master/common/app/implicits/ItemKickerImplicits.scala#L40
+    // Really this logic should live upstream though
+    switch (kicker.type) {
+        case "FreeHtmlKicker":
+            return kicker.item.properties.kickerText || "";
+        default:
+            return "";
+    }
+};


### PR DESCRIPTION
Only supports free html initially (and not even html), but we'll expand as we go.

But really, this kind of thing should live upstream to avoid duplication between clients.

<img width="593" alt="Screenshot 2019-11-05 at 15 16 11" src="https://user-images.githubusercontent.com/858402/68223248-5b3f1d00-ffe4-11e9-89eb-02ae03efeb82.png">
