### PR TITLE
Dynamically fetch image salt

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,10 @@
+import aws from "aws-sdk";
+
+process.env.AWS_PROFILE = "frontend";
+
+const client = new aws.SSM({ region: "eu-west-1" });
+
+export const getParam = async (path: string): Promise<string> => {
+    const value = await client.getParameter({ Name: path }).promise();
+    return value.Parameter.Value;
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,16 +4,17 @@ import asyncHandler from "express-async-handler";
 import { api } from "./api";
 import { Email } from "./Email";
 import { Text } from "./Text";
+import { getParam } from "./config";
 
 const app = express();
 
 app.use(express.json({ limit: "50mb" }));
 app.use(compression());
 
-const salt = process.env.IMAGE_SALT;
-if (!salt) {
-    throw new Error("Required IMAGE_SALT env var is empty");
-}
+// Prefer env var (as quicker), but otherwise grab from config
+const imageSalt: Promise<string> = process.env.IMAGE_SALT
+    ? Promise.resolve(process.env.IMAGE_SALT)
+    : getParam("/frontend/images.signature-salt");
 
 // HTML version as JSON - for Braze/clients
 app.get(
@@ -53,6 +54,7 @@ app.get(
 );
 
 const getFront = async (path: string): Promise<string> => {
+    const salt = await imageSalt;
     const front = await api.get(path);
     return Email(front, salt);
 };


### PR DESCRIPTION
This saves having to manually set up the IMAGE_SALT env var locally before running.

Note, we still look for the var but then fallback to fetching from parameter store. The env var is preferred as it will be quicker in the lambda.