### PR TITLE
Split global CSS out for readability + update fonts

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "express": "^4.17.1",
     "express-async-handler": "^1.1.4",
     "md5": "^2.2.1",
+    "minify-css-string": "^1.0.0",
     "react": "^16.11.0",
     "react-dom": "^16.11.0"
   }

--- a/src/Email.tsx
+++ b/src/Email.tsx
@@ -7,6 +7,9 @@ import { Footer } from "./components/Footer";
 import { Heading } from "./components/Heading";
 import { Multiline } from "./components/Multiline";
 import { Center } from "./layout/Center";
+import { default as minifyCssString } from "minify-css-string";
+import { fontStyles } from "./styles/fonts";
+import { responsiveStyles } from "./styles/responsive-styles";
 
 const canonicalURL = (path: string): string =>
     `https://www.theguardian.com/${path}`;
@@ -58,6 +61,7 @@ export const Email = (front: Front, salt: string): string => {
         <link rel="canonical" href="${canonicalURL(front.id)}" />
         <link rel="icon" href="https://static.guim.co.uk/images/${favicon}">
         <title>${title(front.id)}</title>
+
         <!--[if mso]>
         <style>
             h1, h2, h3, h4, h5, h6, p, blockquote {
@@ -65,14 +69,12 @@ export const Email = (front: Front, salt: string): string => {
             }
         </style>
         <![endif]-->
-        <style>td {padding: 0} .ft__links a:visited { font-family: Helvetica, Arial, sans-serif !important; color: rgb(255, 255, 255) !important; font-size: 12px !important; font-weight: lighter !important; line-height: 14px !important; text-decoration: none !important } .ft__links a:hover { font-family: Helvetica, Arial, sans-serif !important; color: rgb(255, 255, 255) !important; font-size: 12px !important; font-weight: lighter !important; line-height: 14px !important; text-decoration: none !important } .ft__links a:active { font-family: Helvetica, Arial, sans-serif !important; color: rgb(255, 255, 255) !important; font-size: 12px !important; font-weight: lighter !important; line-height: 14px !important; text-decoration: none !important } .free-text a:hover { color: rgb(5, 86, 137) !important } @media screen and (-webkit-min-device-pixel-ratio: 0) {td { -webkit-font-smoothing: antialiased } } @-moz-document url-prefix(){td{-moz-osx-font-smoothing:grayscale}} @font-face {font-family: "Guardian Egyptian Web Header"; src: url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Bold.woff2) format("woff2"), url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Bold.woff) format("woff"); font-weight: 700; font-style: normal} @font-face {font-family: "Guardian Egyptian Web Headline"; src: url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Medium.woff2) format("woff2"), url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Medium.woff) format("woff"); font-weight: 600; font-style: normal} @font-face {font-family: "Guardian Egyptian Web Headline Italic"; src: url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-RegularItalic.woff2) format("woff2"), url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-RegularItalic.woff) format("woff"); font-weight: 400; font-style: normal} @media only screen and (max-width: 600px) {.center-element { min-width: 0 !important } .container { width: 100% !important } }</style>
+
+        <style>${minifyCssString(fontStyles + responsiveStyles)}</style>
+
         <style type="text/css">
         u + .body a,
         #MessageViewBody a { color: inherit; text-decoration: none; font-size: inherit; font-family: inherit; font-weight: inherit; line-height: inherit }
-        @media screen and (max-width: 480px) {
-            .m-pad { padding-right: 10px !important }
-            .m-col-pad { padding-bottom: 15px !important }
-        }
         </style>
     </head>
     <body class="body" style="min-width:100%;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;margin:0;padding:0;box-sizing:border-box;width:100%">

--- a/src/Email.tsx
+++ b/src/Email.tsx
@@ -45,6 +45,8 @@ export const Email = (front: Front, salt: string): string => {
 
     const html = `
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<!-- https://litmus.com/community/snippets/112-outlook-2013-120dpi-make-images-scale-properly -->
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" lang="en" xml:lang="en">
     <head>
         <!--[if gte mso 9]>
@@ -62,6 +64,7 @@ export const Email = (front: Front, salt: string): string => {
         <link rel="icon" href="https://static.guim.co.uk/images/${favicon}">
         <title>${title(front.id)}</title>
 
+        <!-- Font resets for MS Outlook -->
         <!--[if mso]>
         <style>
             h1, h2, h3, h4, h5, h6, p, blockquote {
@@ -71,14 +74,9 @@ export const Email = (front: Front, salt: string): string => {
         <![endif]-->
 
         <style>${minifyCssString(fontStyles + responsiveStyles)}</style>
-
-        <style type="text/css">
-        u + .body a,
-        #MessageViewBody a { color: inherit; text-decoration: none; font-size: inherit; font-family: inherit; font-weight: inherit; line-height: inherit }
-        </style>
     </head>
     <body class="body" style="min-width:100%;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;margin:0;padding:0;box-sizing:border-box;width:100%">
-            ${body}
+        ${body}
     </body>
 </html>`;
 

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -56,7 +56,7 @@ const linkStyle: FontCSS = {
 const headlineStyle = (size: Size): FontCSS => {
     return {
         color: palette.neutral[7],
-        fontFamily: "'Guardian Egyptian Web Headline', Georgia, serif",
+        fontFamily: "'GH Guardian Headline', Georgia, serif",
         fontWeight: 400,
 
         ...fontSizes[size]
@@ -72,7 +72,8 @@ const kickerStyle: FontCSS = {
 const bylineStyle = (size: Size): FontCSS => {
     return {
         color: palette.culture.main,
-        fontFamily: "'Guardian Egyptian Web Headline Italic', Georgia, serif",
+        fontFamily: "'GH Guardian Headline', Georgia, serif",
+        fontStyle: "italic",
 
         ...fontSizes[size]
     };

--- a/src/components/Heading.tsx
+++ b/src/components/Heading.tsx
@@ -9,17 +9,19 @@ const tableStyle: TableCSS = {
 };
 
 const headingStyle: TdCSS = {
-    fontFamily: "'Guardian Egyptian Web Header', Georgia, serif",
+    fontFamily: "'GH Guardian Headline', Georgia, serif",
     fontSize: "22px",
     lineHeight: "26px",
     color: palette.neutral[7],
-    padding: "0 10px 12px",
+    padding: "0 10px 12px"
 };
 
 export const Heading: React.FC<{ heading: string }> = ({ heading }) => (
     <table style={tableStyle}>
         <tr>
-            <td className="m-heading" style={headingStyle}>{heading}</td>
+            <td className="m-heading" style={headingStyle}>
+                {heading}
+            </td>
         </tr>
     </table>
 );

--- a/src/components/Multiline.tsx
+++ b/src/components/Multiline.tsx
@@ -25,8 +25,8 @@ export const Multiline: React.FC<{}> = () => (
         <tr>
             <td style={tdStyle}>
                 <table style={tableStyle}>
-                    {[0, 1, 2, 3].map(line => (
-                        <tr>
+                    {[0, 1, 2, 3].map((line, i) => (
+                        <tr key={i}>
                             <td style={lineStyle}>&nbsp;</td>
                         </tr>
                     ))}

--- a/src/layout/Grid.tsx
+++ b/src/layout/Grid.tsx
@@ -38,8 +38,8 @@ export const Grid: React.FC<Props> = ({ content, salt }) => {
     }
 
     const rows = pairs.map((pair, i) => (
-        <>
-            <tr key={i} style={rowStyle}>
+        <React.Fragment key={i}>
+            <tr style={rowStyle}>
                 <td style={colStyle}>
                     <Card content={pair[0]} salt={salt} size={"small"} />
                 </td>
@@ -48,10 +48,10 @@ export const Grid: React.FC<Props> = ({ content, salt }) => {
                     <Card content={pair[1]} salt={salt} size={"small"} />
                 </td>
             </tr>
-            <tr key={i + "pad"}>
+            <tr>
                 <td style={{ paddingTop: "10px" }}></td>
             </tr>
-        </>
+        </React.Fragment>
     ));
 
     return <table style={tableStyle}>{rows}</table>;

--- a/src/styles/fonts.ts
+++ b/src/styles/fonts.ts
@@ -3,6 +3,18 @@ td {
     padding: 0;
 }
 
+/** https://litmus.com/community/snippets/113-override-gmail-blue-links **/
+/** https://litmus.com/community/snippets/118-remove-samsung-blue-links **/
+u + .body a,
+#MessageViewBody a {
+    color: inherit;
+    text-decoration: none;
+    font-size: inherit;
+    font-family: inherit;
+    font-weight: inherit;
+    line-height: inherit
+}
+
 .ft__links a:visited {
     font-family: Helvetica, Arial, sans-serif !important;
     color: rgb(255, 255, 255) !important;

--- a/src/styles/fonts.ts
+++ b/src/styles/fonts.ts
@@ -1,3 +1,5 @@
+const CDNFontPath = "https://assets.guim.co.uk/static/frontend";
+
 export const fontStyles = `
 td {
     padding: 0;
@@ -53,32 +55,26 @@ u + .body a,
 }
 
 @font-face {
-    font-family: "Guardian Egyptian Web Header";
-    src: url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Bold.woff2)
-            format("woff2"),
-        url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Bold.woff)
-            format("woff");
+    font-family: "GH Guardian Headline";
+    src: url(${CDNFontPath}/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2) format("woff2"),
+         url(${CDNFontPath}/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff) format("woff");
     font-weight: 700;
-    font-style: normal;
+    font-style: bold;
 }
 
 @font-face {
-    font-family: "Guardian Egyptian Web Headline";
-    src: url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Medium.woff2)
-            format("woff2"),
-        url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Medium.woff)
-            format("woff");
-    font-weight: 600;
-    font-style: normal;
-}
-
-@font-face {
-    font-family: "Guardian Egyptian Web Headline Italic";
-    src: url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-RegularItalic.woff2)
-            format("woff2"),
-        url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-RegularItalic.woff)
-            format("woff");
+    font-family: "GH Guardian Headline";
+    src: url(${CDNFontPath}/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff2) format("woff2"),
+         url(${CDNFontPath}/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff) format("woff");
     font-weight: 400;
     font-style: normal;
+}
+
+@font-face {
+    font-family: "GH Guardian Headline";
+    src: url(${CDNFontPath}/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff2) format("woff2"),
+         url(${CDNFontPath}/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff) format("woff");
+    font-weight: 400;
+    font-style: italic;
 }
 `;

--- a/src/styles/fonts.ts
+++ b/src/styles/fonts.ts
@@ -1,0 +1,72 @@
+export const fontStyles = `
+td {
+    padding: 0;
+}
+
+.ft__links a:visited {
+    font-family: Helvetica, Arial, sans-serif !important;
+    color: rgb(255, 255, 255) !important;
+    font-size: 12px !important;
+    font-weight: lighter !important;
+    line-height: 14px !important;
+    text-decoration: none !important;
+}
+
+.ft__links a:hover {
+    font-family: Helvetica, Arial, sans-serif !important;
+    color: rgb(255, 255, 255) !important;
+    font-size: 12px !important;
+    font-weight: lighter !important;
+    line-height: 14px !important;
+    text-decoration: none !important;
+}
+
+.ft__links a:active {
+    font-family: Helvetica, Arial, sans-serif !important;
+    color: rgb(255, 255, 255) !important;
+    font-size: 12px !important;
+    font-weight: lighter !important;
+    line-height: 14px !important;
+    text-decoration: none !important;
+}
+
+.free-text a:hover {
+    color: rgb(5, 86, 137) !important;
+}
+
+@-moz-document url-prefix() {
+    td {
+        -moz-osx-font-smoothing: grayscale;
+    }
+}
+
+@font-face {
+    font-family: "Guardian Egyptian Web Header";
+    src: url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Bold.woff2)
+            format("woff2"),
+        url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Bold.woff)
+            format("woff");
+    font-weight: 700;
+    font-style: normal;
+}
+
+@font-face {
+    font-family: "Guardian Egyptian Web Headline";
+    src: url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Medium.woff2)
+            format("woff2"),
+        url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Medium.woff)
+            format("woff");
+    font-weight: 600;
+    font-style: normal;
+}
+
+@font-face {
+    font-family: "Guardian Egyptian Web Headline Italic";
+    src: url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-RegularItalic.woff2)
+            format("woff2"),
+        url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-RegularItalic.woff)
+            format("woff");
+    font-weight: 400;
+    font-style: normal;
+}
+`;

--- a/src/styles/responsive-styles.ts
+++ b/src/styles/responsive-styles.ts
@@ -1,0 +1,21 @@
+export const responsiveStyles = `
+@media only screen and (max-width: 600px) {
+    .center-element {
+        min-width: 0 !important;
+    }
+    .container {
+        width: 100% !important;
+    }
+}
+
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+    td {
+        -webkit-font-smoothing: antialiased;
+    }
+}
+
+@media screen and (max-width: 480px) {
+    .m-pad { padding-right: 10px !important }
+    .m-col-pad { padding-bottom: 15px !important }
+}
+`;

--- a/src/third-party.d.ts
+++ b/src/third-party.d.ts
@@ -1,0 +1,4 @@
+declare module "minify-css-string" {
+    const minifyCSSString: any;
+    export default minifyCSSString;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2820,6 +2820,11 @@ mime@1.6.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
+minify-css-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/minify-css-string/-/minify-css-string-1.0.0.tgz#201bd949271e19f6e0af0a1dc0ccc583de47c630"
+  integrity sha1-IBvZSSceGfbgrwodwMzFg95HxjA=
+
 minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"


### PR DESCRIPTION
The aim is to separate out the global CSS to make it easier to maintain and also updates fonts to the newest versions.

In a later PR I hope to verify all of the CSS is needed and also rework the font declarations to use the newest font versions.

Note, we don't get editor support for the css unfortunately, but it is still an improvement over the status quo. I did look into importing CSS files directly in Typescript, but it seems difficult without using Webpack or equivalent, which doesn't really seem justified.