### PR TITLE
Setting the height on the quote icon height attribute fixes the issue with…

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -83,7 +83,6 @@ const bottomPaddingStyle: TdCSS = {
 };
 
 const quoteIconStyle: ImageCSS = {
-    height: "0.8em",
     display: "inline-block"
 };
 
@@ -152,6 +151,7 @@ export const Card: React.FC<Props> = ({ content, salt, size }) => {
                                         {isComment && (
                                             <>
                                                 <img
+                                                    height={"16"}
                                                     style={quoteIconStyle}
                                                     src="https://assets.guim.co.uk/images/email/icons/9682728db696148fd5a6b149e556df8c/quote-culture.png"
                                                     alt="quote icon"


### PR DESCRIPTION
Setting the height on the image height attribute fixes the issue with quote icon being resized on some of the email clients.