### PR TITLE
Disable type error on bgcolor

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -50,6 +50,8 @@ export const Footer: React.FC<{}> = () => (
         <table style={tableStyle}>
             <tr>
                 <td style={{ paddingTop: "10px" }}>
+                    // @ts-ignore: bgcolor is deprecated but we require it for
+                    // certain clients.
                     <table bgcolor={palette.neutral[20]} style={tableWrapper}>
                         <tr>
                             <td style={tdInnerPadding}>


### PR DESCRIPTION
As we require it even though the attribute is deprecated in modern browsers.

Means we no longer need to use `--no-verify` when we push! :)