### PR TITLE
Removing border around the quote image 

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -84,7 +84,8 @@ const bottomPaddingStyle: TdCSS = {
 
 const quoteIconStyle: ImageCSS = {
     height: "0.8em",
-    display: "inline-block"
+    display: "inline-block",
+    border: "0"
 };
 
 interface Props {


### PR DESCRIPTION
Removing border around the quote image on Lotus Notes 8.5 and Outlook 2003.