### PR TITLE
Headline and the quoted icon appearance matched

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -107,10 +107,15 @@ interface Header {
     headline: string;
 }
 
+interface Display {
+    showQuotedHeadline: boolean;
+}
+
 export interface Content {
     properties: Properties;
     card: Card;
     header: Header;
+    display: Display;
 
     cardStyle: {
         type: string;

--- a/src/components/cards/DefaultCard.tsx
+++ b/src/components/cards/DefaultCard.tsx
@@ -111,12 +111,12 @@ export const DefaultCard: React.FC<Props> = ({ content, salt, size }) => {
         content.card.starRating
     );
 
-    const headline = content.properties.webTitle;
+    const headline = content.header.headline;
     const byline = content.properties.byline;
     const webURL = content.properties.webUrl + brazeParameter;
     const imageURL = formattedImage;
     const imageAlt = image.fields.altText;
-    const isComment = content.header.isComment;
+    const isComment = content.display.showQuotedHeadline;
 
     const kicker = content.header.kicker
         ? kickerText(content.header.kicker)


### PR DESCRIPTION
The headline and the quoted icon appearance matched with the original film-today email.
To apply correct headline, I have pointed the headline to "content.header.headline" instead of "content.properties.webTitle". Additionally, in order to make quoted icon visible, I have pointed this to "content.display.showQuotedHeadline" instead of "content.header.isComment", and this now works correctly.