### PR TITLE
Use single large card for default and fail grid gracefully

### DIFF
--- a/src/components/Collection.tsx
+++ b/src/components/Collection.tsx
@@ -17,10 +17,9 @@ export const DefaultCollection: React.FC<{
     }
 
     // TODO handle curated collections
-    const rest = collection.backfill.slice(2);
+    const rest = collection.backfill.slice(1);
 
     const contentOne = collection.backfill[0];
-    const contentTwo = collection.backfill[1];
 
     return (
         <>
@@ -30,9 +29,6 @@ export const DefaultCollection: React.FC<{
             <Card content={contentOne} salt={salt} size={"large"} />
             <Padding px={10} />
 
-            {contentTwo && (
-                <Card content={contentTwo} salt={salt} size={"large"} />
-            )}
             <Padding px={10} />
 
             {rest && <DefaultGrid content={rest} salt={salt} />}

--- a/src/layout/Grid.tsx
+++ b/src/layout/Grid.tsx
@@ -75,7 +75,11 @@ export const DefaultGrid: React.FC<DefaultGridProps> = ({ content, salt }) => {
         <React.Fragment key={i}>
             <GridRow
                 left={<Card content={pair[0]} salt={salt} size={"small"} />}
-                right={<Card content={pair[1]} salt={salt} size={"small"} />}
+                right={
+                    pair[1] ? (
+                        <Card content={pair[1]} salt={salt} size={"small"} />
+                    ) : null
+                }
             />
 
             <Padding px={10} />


### PR DESCRIPTION
To handle 7 items (not 8) for the film collection and also fail (kind of) gracefully with the grid when there is an odd number of items.