### PR TITLE
Remove contributor inage table if no images and fix padding

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -55,7 +55,7 @@ interface Image {
     fields: { altText: string };
 }
 
-interface Tag {
+export interface Tag {
     properties: {
         tagType: string;
         contributorLargeImagePath?: string;

--- a/src/components/cards/CommentCard.tsx
+++ b/src/components/cards/CommentCard.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { FontCSS, TdCSS, ImageCSS } from "../../css";
 import { palette } from "@guardian/src-foundations";
-import { Content } from "../../api";
+import { Content, Tag } from "../../api";
 import { formatImage } from "../../image";
 import { kickerText } from "../../kicker";
 import sanitizeHtml from "sanitize-html";
@@ -50,7 +50,7 @@ const tdStyle: TdCSS = {
 const metaWrapperStyle = (size: Size): TdCSS => {
     const rightPad = size === "large" ? "40px" : "10px";
     return {
-        padding: `3px ${rightPad} 5px 10px`
+        padding: `3px ${rightPad} 10px 10px`
     };
 };
 
@@ -355,16 +355,18 @@ export const CommentCard: React.FC<Props> = ({
     );
 };
 
+export const getContributor = (content: Content): Tag => {
+    return content.properties.maybeContent.tags.tags.find(tag => {
+        return tag.properties.tagType === "Contributor";
+    });
+};
+
 export const ContributorImageWrapper: React.FC<{
     content: Content;
     salt: string;
 }> = ({ content, salt }) => {
-    const contributor = content.properties.maybeContent.tags.tags.find(tag => {
-        return tag.properties.tagType === "Contributor";
-    });
-    const profilePic = contributor
-        ? contributor.properties.contributorLargeImagePath
-        : null;
+    const contributor = getContributor(content);
+    const profilePic = contributor.properties.contributorLargeImagePath || null;
 
     return (
         <ContributorImage

--- a/src/layout/Grid.tsx
+++ b/src/layout/Grid.tsx
@@ -3,10 +3,11 @@ import { Content } from "../api";
 import { Card } from "../components/cards/Card";
 import {
     ContributorImageWrapper,
-    CommentCard
+    CommentCard,
+    getContributor
 } from "../components/cards/CommentCard";
 import { LinkCard } from "../components/cards/LinkCard";
-import { TdCSS, TrCSS, TableCSS } from "../css";
+import { TdCSS, TableCSS } from "../css";
 import { palette } from "@guardian/src-foundations";
 import { TableRow } from "./Table";
 import { Padding } from "./Padding";
@@ -20,7 +21,6 @@ const gutterStyle: TdCSS = {
     width: "2%"
 };
 
-type Align = "left" | "right";
 type VAlign = "top" | "bottom";
 
 interface RowStyle {
@@ -131,21 +131,23 @@ export const CommentGrid: React.FC<CommentGridProps> = ({
     shouldShowGridImages
 }) => {
     const rows = partition(content, 2).map((pair, i) => {
+        const hasContributor = pair.find(content => {
+            const contributor = getContributor(content);
+            return contributor.properties.contributorLargeImagePath;
+        });
+
         const contributorLeft = (
-            <TableRow>
-                <td style={{ width: "50%" }}></td>
-                <td style={{ width: "50%" }}>
-                    <ContributorImageWrapper content={pair[0]} salt={salt} />
-                </td>
-            </TableRow>
+            <ContributorImageWrapper content={pair[0]} salt={salt} />
         );
 
         const contributorRight = (
+            <ContributorImageWrapper content={pair[1]} salt={salt} />
+        );
+
+        const contributor = (node: React.ReactNode): React.ReactNode => (
             <TableRow>
                 <td style={{ width: "50%" }}></td>
-                <td style={{ width: "50%" }}>
-                    <ContributorImageWrapper content={pair[1]} salt={salt} />
-                </td>
+                <td style={{ width: "50%" }}>{node}</td>
             </TableRow>
         );
 
@@ -171,18 +173,20 @@ export const CommentGrid: React.FC<CommentGridProps> = ({
                     leftStyles={{ backgroundColor: palette.opinion.faded }}
                     rightStyles={{ backgroundColor: palette.opinion.faded }}
                 />
-                <GridRow
-                    left={contributorLeft}
-                    right={contributorRight}
-                    leftStyles={{
-                        backgroundColor: palette.opinion.faded,
-                        verticalAlign: "bottom"
-                    }}
-                    rightStyles={{
-                        backgroundColor: palette.opinion.faded,
-                        verticalAlign: "bottom"
-                    }}
-                />
+                {hasContributor && (
+                    <GridRow
+                        left={contributor(contributorLeft)}
+                        right={contributor(contributorRight)}
+                        leftStyles={{
+                            backgroundColor: palette.opinion.faded,
+                            verticalAlign: "bottom"
+                        }}
+                        rightStyles={{
+                            backgroundColor: palette.opinion.faded,
+                            verticalAlign: "bottom"
+                        }}
+                    />
+                )}
 
                 <Padding px={10} />
             </React.Fragment>


### PR DESCRIPTION
To remove vertical padding/empty space from the table if no contributor images in smaller comment cards (displayed within the grid).