### PR TITLE
Opinion 'C' variant

### DIFF
--- a/bin/upload.sh
+++ b/bin/upload.sh
@@ -9,10 +9,11 @@ then
     exit 1
 fi
 
-wget --quiet localhost:3030/film-today.json --directory-prefix=tmp/
-wget --quiet localhost:3030/film-today/text.json --directory-prefix=tmp/
+wget --quiet localhost:3030/film-today.json --directory-prefix=tmp/film/
+wget --quiet localhost:3030/film-today/text.json --directory-prefix=tmp/film/
 
-wget --quiet localhost:3030/opinion.json --directory-prefix=tmp/
-wget --quiet localhost:3030/opinion/text.json --directory-prefix=tmp/
+wget --quiet localhost:3030/opinion/text.json --directory-prefix=tmp/opinion-b/
+wget --quiet localhost:3030/opinion.json --directory-prefix=tmp/opinion-b/
+wget --quiet localhost:3030/opinion.json?variant=c --directory-prefix=tmp/opinion-c/
 
 aws s3 cp --profile=frontend --acl=public-read --recursive tmp/ s3://aws-frontend-emails-test/

--- a/src/Email.tsx
+++ b/src/Email.tsx
@@ -24,7 +24,7 @@ const title = (id: string): string => {
     );
 };
 
-export const Email = (front: Front, salt: string): string => {
+export const Email = (front: Front, salt: string, variant?: string): string => {
     const body = renderToStaticMarkup(
         <Center>
             <TableRowCell>
@@ -33,6 +33,7 @@ export const Email = (front: Front, salt: string): string => {
                     frontId={front.id}
                     collections={front.collections}
                     salt={salt}
+                    variant={variant}
                 />
                 <Footer id={front.id} />
             </TableRowCell>

--- a/src/Email.tsx
+++ b/src/Email.tsx
@@ -63,19 +63,21 @@ export const Email = (front: Front, salt: string, variant?: string): string => {
         <meta name="viewport" content="width=device-width" />
         <meta name="robots" content="noindex" />
         <link rel="canonical" href="${canonicalURL(front.id)}" />
-        <link rel="icon" href="https://static.guim.co.uk/images/${favicon}">
+        <link rel="icon" href="https://static.guim.co.uk/images/${favicon}" />
         <title>${title(front.id)}</title>
 
         <!-- Font resets for MS Outlook -->
         <!--[if mso]>
-        <style>
+        <style type="text/css">
             h1, h2, h3, h4, h5, h6, p, blockquote {
                 font-family: Georgia, serif !important;
             }
         </style>
         <![endif]-->
 
-        <style>${minifyCssString(fontStyles + responsiveStyles)}</style>
+        <style type="text/css">${minifyCssString(
+            fontStyles + responsiveStyles
+        )}</style>
     </head>
     <body class="body" style="min-width:100%;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;margin:0;padding:0;box-sizing:border-box;width:100%">
         ${body}

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ImageCSS } from "../css";
-import { Table } from "../layout/Table";
+import { TableRowCell } from "../layout/Table";
 
 const imgStyle: ImageCSS = {
     outline: "none",
@@ -29,13 +29,13 @@ export const Banner: React.FC<{ frontID: string }> = ({ frontID }) => {
     const bannerAltText = bannersAlt[frontID] || bannersAlt.default;
 
     return (
-        <Table>
+        <TableRowCell>
             <img
                 width="600"
                 src={bannerSrc}
                 alt={bannerAltText}
                 style={imgStyle}
             ></img>
-        </Table>
+        </TableRowCell>
     );
 };

--- a/src/components/Collection.tsx
+++ b/src/components/Collection.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { Collection as ICollection } from "../api";
 import { Card } from "./cards/Card";
-import { CommentCard } from "./cards/CommentCard";
 import { MediaCard } from "./cards/MediaCard";
-import { DefaultGrid, CommentGrid, LinkGrid } from "../layout/Grid";
+import { Card as CommentCard } from "./tests/commentB/Card";
+import { DefaultGrid, LinkGrid } from "../layout/Grid";
 import { Padding } from "../layout/Padding";
 import { Heading } from "./Heading";
 import { Multiline } from "./Multiline";
@@ -56,83 +56,6 @@ export const EditorialCollection: React.FC<{
                 salt={salt}
                 size={"large"}
                 shouldShowImage={true}
-            />
-        </>
-    );
-};
-
-const frontIdShouldShowCommentGridImages = (frontId: string): boolean => {
-    if (frontId === "email/opinion") {
-        return false;
-    }
-    return true;
-};
-
-export const CommentCollection: React.FC<{
-    frontId: string;
-    collection: ICollection;
-    salt: string;
-}> = ({ frontId, collection, salt }) => {
-    // TODO handle curated collections
-
-    const c0 = collection.backfill[0];
-    const c1 = collection.backfill[1];
-    const grid_2_5 = collection.backfill.slice(2, 6);
-    const c6 = collection.backfill[6];
-    const grid_7_8 = collection.backfill.slice(7, 9);
-    const c9 = collection.backfill[9];
-
-    // TODO
-    return (
-        <>
-            <Multiline />
-            <Heading heading={collection.displayName} />
-
-            <CommentCard
-                content={c0}
-                salt={salt}
-                size={"large"}
-                shouldShowImage={false}
-            />
-            <Padding px={10} />
-
-            <CommentCard
-                content={c1}
-                salt={salt}
-                size={"large"}
-                shouldShowImage={false}
-            />
-            <Padding px={10} />
-
-            <CommentGrid
-                content={grid_2_5}
-                salt={salt}
-                shouldShowGridImages={frontIdShouldShowCommentGridImages(
-                    frontId
-                )}
-            />
-
-            <CommentCard
-                content={c6}
-                salt={salt}
-                size={"large"}
-                shouldShowImage={false}
-            />
-            <Padding px={10} />
-
-            <CommentGrid
-                content={grid_7_8}
-                salt={salt}
-                shouldShowGridImages={frontIdShouldShowCommentGridImages(
-                    frontId
-                )}
-            />
-
-            <CommentCard
-                content={c9}
-                salt={salt}
-                size={"large"}
-                shouldShowImage={false}
             />
         </>
     );

--- a/src/components/Collection.tsx
+++ b/src/components/Collection.tsx
@@ -36,31 +36,6 @@ export const DefaultCollection: React.FC<{
     );
 };
 
-export const EditorialCollection: React.FC<{
-    collection: ICollection;
-    salt: string;
-}> = ({ collection, salt }) => {
-    // TODO handle curated collections
-    const rest = collection.backfill.slice(2);
-
-    const contentOne = collection.backfill[0];
-
-    // TODO
-    return (
-        <>
-            <Multiline />
-            <Heading heading={collection.displayName} />
-
-            <CommentCard
-                content={contentOne}
-                salt={salt}
-                size={"large"}
-                shouldShowImage={true}
-            />
-        </>
-    );
-};
-
 export const MediaCollection: React.FC<{
     collection: ICollection;
     salt: string;

--- a/src/components/Collection.tsx
+++ b/src/components/Collection.tsx
@@ -29,8 +29,6 @@ export const DefaultCollection: React.FC<{
             <Card content={contentOne} salt={salt} size={"large"} />
             <Padding px={10} />
 
-            <Padding px={10} />
-
             {rest && <DefaultGrid content={rest} salt={salt} />}
         </>
     );

--- a/src/components/Collection.tsx
+++ b/src/components/Collection.tsx
@@ -67,7 +67,6 @@ export const LinkCollection: React.FC<{
         <>
             <Multiline />
             <Heading heading={collection.displayName} />
-
             {content && <LinkGrid content={content} salt={salt} />}
         </>
     );

--- a/src/components/Collections.tsx
+++ b/src/components/Collections.tsx
@@ -2,12 +2,17 @@ import React from "react";
 import { Collection as ICollection } from "../api";
 import {
     DefaultCollection,
-    EditorialCollection,
     LinkCollection,
     MediaCollection
 } from "./Collection";
-import { Collection as CommentCollectionB } from "./tests/commentB/Collection";
-import { Collection as CommentCollectionC } from "./tests/commentC/Collection";
+import {
+    Collection as CommentCollectionB,
+    EditorialCollection as EditorialCollectionB
+} from "./tests/commentB/Collection";
+import {
+    Collection as CommentCollectionC,
+    EditorialCollection as EditorialCollectionC
+} from "./tests/commentC/Collection";
 import { Content } from "../api";
 import { TableRowCell } from "../layout/Table";
 
@@ -53,11 +58,19 @@ export const Collections: React.FC<{
 
         switch (designType) {
             case "editorial":
+                if (variant === "c") {
+                    return (
+                        <EditorialCollectionC
+                            collection={collection}
+                            salt={salt}
+                        />
+                    );
+                }
+
                 return (
-                    <EditorialCollection collection={collection} salt={salt} />
+                    <EditorialCollectionB collection={collection} salt={salt} />
                 );
             case "comment":
-                console.log("variant is: " + variant);
                 if (variant === "c") {
                     return (
                         <CommentCollectionC

--- a/src/components/Collections.tsx
+++ b/src/components/Collections.tsx
@@ -6,7 +6,8 @@ import {
     LinkCollection,
     MediaCollection
 } from "./Collection";
-import { Collection as CommentCollection } from "./tests/commentB/Collection";
+import { Collection as CommentCollectionB } from "./tests/commentB/Collection";
+import { Collection as CommentCollectionC } from "./tests/commentC/Collection";
 import { Content } from "../api";
 import { TableRowCell } from "../layout/Table";
 
@@ -44,7 +45,8 @@ export const Collections: React.FC<{
     frontId: string;
     collections: ICollection[];
     salt: string;
-}> = ({ frontId, collections, salt }) => {
+    variant?: string;
+}> = ({ frontId, collections, salt, variant }) => {
     const res = collections.map(collection => {
         const content = [].concat(collection.backfill, collection.curated); // TODO support curated too
         const designType = getDesignType(content);
@@ -55,8 +57,19 @@ export const Collections: React.FC<{
                     <EditorialCollection collection={collection} salt={salt} />
                 );
             case "comment":
+                console.log("variant is: " + variant);
+                if (variant === "c") {
+                    return (
+                        <CommentCollectionC
+                            frontId={frontId}
+                            collection={collection}
+                            salt={salt}
+                        />
+                    );
+                }
+
                 return (
-                    <CommentCollection
+                    <CommentCollectionB
                         frontId={frontId}
                         collection={collection}
                         salt={salt}

--- a/src/components/Collections.tsx
+++ b/src/components/Collections.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { Collection as ICollection } from "../api";
 import {
-    CommentCollection,
     DefaultCollection,
     EditorialCollection,
-    MediaCollection,
-    LinkCollection
+    LinkCollection,
+    MediaCollection
 } from "./Collection";
+import { Collection as CommentCollection } from "./tests/commentB/Collection";
 import { Content } from "../api";
 import { TableRowCell } from "../layout/Table";
 

--- a/src/components/Collections.tsx
+++ b/src/components/Collections.tsx
@@ -56,6 +56,10 @@ export const Collections: React.FC<{
         const content = [].concat(collection.backfill, collection.curated); // TODO support curated too
         const designType = getDesignType(content);
 
+        if (collection.displayName === "Save 50% for three months") {
+            return null; // ignore the jobs collection for now
+        }
+
         switch (designType) {
             case "editorial":
                 if (variant === "c") {

--- a/src/components/cards/Card.tsx
+++ b/src/components/cards/Card.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { DefaultCard } from "./DefaultCard";
-import { CommentCard } from "./CommentCard";
+import { Card as CommentCard } from "../tests/commentB/Card";
 import { Content } from "../../api";
 
 type CardType = "default" | "comment";

--- a/src/components/cards/LinkCard.tsx
+++ b/src/components/cards/LinkCard.tsx
@@ -45,7 +45,7 @@ export const LinkCard: React.FC<{
                 {content.header.headline}
                 <br />
                 <br />
-                <img height="23" style={iconStyle} src={arrow} alt={arrow} />
+                <img height="23" style={iconStyle} src={arrow} alt="arrow" />
             </a>
         </TableRowCell>
     );

--- a/src/components/cards/LinkCard.tsx
+++ b/src/components/cards/LinkCard.tsx
@@ -29,7 +29,10 @@ export const LinkCard: React.FC<{
     content: Content;
     theme: Theme;
 }> = ({ content, theme }) => {
-    const webURL = content.properties.href + brazeParameter; // TODO type curated content separately?
+    const webURL =
+        "https://www.theguardian.com" +
+        content.properties.href +
+        brazeParameter; // TODO type curated content separately?
 
     const arrow =
         theme === "light"

--- a/src/components/tests/commentB/Card.tsx
+++ b/src/components/tests/commentB/Card.tsx
@@ -5,7 +5,7 @@ import { Content, Tag } from "../../../api";
 import { formatImage } from "../../../image";
 import { kickerText } from "../../../kicker";
 import sanitizeHtml from "sanitize-html";
-import { Table, RowCell, TableRowCell } from "../../../layout/Table";
+import { Table, RowCell, TableRowCell, TableRow } from "../../../layout/Table";
 
 type Size = "small" | "large";
 
@@ -196,10 +196,10 @@ const SupplementaryMeta: React.FC<{
     if (trailText && contributorImageSrc) {
         return (
             <RowCell>
-                <Table>
+                <TableRow>
                     <TrailText text={trailText} linkURL={linkURL} size={size} />
                     {contributorImage}
-                </Table>
+                </TableRow>
             </RowCell>
         );
     } else if (trailText) {

--- a/src/components/tests/commentB/Card.tsx
+++ b/src/components/tests/commentB/Card.tsx
@@ -1,11 +1,11 @@
 import React from "react";
-import { FontCSS, TdCSS, ImageCSS } from "../../css";
+import { FontCSS, TdCSS, ImageCSS } from "../../../css";
 import { palette } from "@guardian/src-foundations";
-import { Content, Tag } from "../../api";
-import { formatImage } from "../../image";
-import { kickerText } from "../../kicker";
+import { Content, Tag } from "../../../api";
+import { formatImage } from "../../../image";
+import { kickerText } from "../../../kicker";
 import sanitizeHtml from "sanitize-html";
-import { Table, RowCell, TableRowCell } from "../../layout/Table";
+import { Table, RowCell, TableRowCell } from "../../../layout/Table";
 
 type Size = "small" | "large";
 
@@ -276,7 +276,7 @@ const Image: React.FC<{
     );
 };
 
-export const CommentCard: React.FC<Props> = ({
+export const Card: React.FC<Props> = ({
     content,
     salt,
     size,

--- a/src/components/tests/commentB/Collection.tsx
+++ b/src/components/tests/commentB/Collection.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { Collection as ICollection } from "../../../api";
+import { Card as CommentCard } from "././../commentB/Card";
+import { MediaCard } from "../../cards/MediaCard";
+import { Padding } from "../../../layout/Padding";
+import { Heading } from "./../../Heading";
+import { Multiline } from "./../../Multiline";
+import { Grid as CommentGrid } from "../commentB/Grid";
+
+const frontIdShouldShowCommentGridImages = (frontId: string): boolean => {
+    if (frontId === "email/opinion") {
+        return false;
+    }
+    return true;
+};
+
+export const Collection: React.FC<{
+    frontId: string;
+    collection: ICollection;
+    salt: string;
+}> = ({ frontId, collection, salt }) => {
+    // TODO handle curated collections
+
+    const c0 = collection.backfill[0];
+    const c1 = collection.backfill[1];
+    const grid_2_5 = collection.backfill.slice(2, 6);
+    const c6 = collection.backfill[6];
+    const grid_7_8 = collection.backfill.slice(7, 9);
+    const c9 = collection.backfill[9];
+
+    // TODO
+    return (
+        <>
+            <Multiline />
+            <Heading heading={collection.displayName} />
+
+            <CommentCard
+                content={c0}
+                salt={salt}
+                size={"large"}
+                shouldShowImage={false}
+            />
+            <Padding px={10} />
+
+            <CommentCard
+                content={c1}
+                salt={salt}
+                size={"large"}
+                shouldShowImage={false}
+            />
+            <Padding px={10} />
+
+            <CommentGrid
+                content={grid_2_5}
+                salt={salt}
+                shouldShowGridImages={frontIdShouldShowCommentGridImages(
+                    frontId
+                )}
+            />
+
+            <CommentCard
+                content={c6}
+                salt={salt}
+                size={"large"}
+                shouldShowImage={false}
+            />
+            <Padding px={10} />
+
+            <CommentGrid
+                content={grid_7_8}
+                salt={salt}
+                shouldShowGridImages={frontIdShouldShowCommentGridImages(
+                    frontId
+                )}
+            />
+
+            <CommentCard
+                content={c9}
+                salt={salt}
+                size={"large"}
+                shouldShowImage={false}
+            />
+        </>
+    );
+};

--- a/src/components/tests/commentB/Collection.tsx
+++ b/src/components/tests/commentB/Collection.tsx
@@ -83,3 +83,25 @@ export const Collection: React.FC<{
         </>
     );
 };
+
+export const EditorialCollection: React.FC<{
+    collection: ICollection;
+    salt: string;
+}> = ({ collection, salt }) => {
+    const contentOne = collection.backfill[0];
+
+    // TODO
+    return (
+        <>
+            <Multiline />
+            <Heading heading={collection.displayName} />
+
+            <CommentCard
+                content={contentOne}
+                salt={salt}
+                size={"large"}
+                shouldShowImage={true}
+            />
+        </>
+    );
+};

--- a/src/components/tests/commentB/Grid.tsx
+++ b/src/components/tests/commentB/Grid.tsx
@@ -1,11 +1,10 @@
 import React from "react";
 import { ContributorImageWrapper, getContributor } from "./Card";
 import { palette } from "@guardian/src-foundations";
-import { TableRow } from "../../../layout/Table";
+import { TableRowCell, TableRow } from "../../../layout/Table";
 import { Padding } from "../../../layout/Padding";
 import { Content } from "../../../api";
 import { GridRow, partition } from "../../../layout/Grid";
-import { TableCSS } from "../../../css";
 import { Card as CommentCard } from "./Card";
 
 interface CommentGridProps {
@@ -13,11 +12,6 @@ interface CommentGridProps {
     salt: string;
     shouldShowGridImages: boolean;
 }
-
-const tableStyle: TableCSS = {
-    borderCollapse: "collapse",
-    borderSpacing: 0
-};
 
 export const Grid: React.FC<CommentGridProps> = ({
     content,
@@ -87,5 +81,5 @@ export const Grid: React.FC<CommentGridProps> = ({
         );
     });
 
-    return <table style={tableStyle}>{rows}</table>;
+    return <TableRowCell>{rows}</TableRowCell>;
 };

--- a/src/components/tests/commentB/Grid.tsx
+++ b/src/components/tests/commentB/Grid.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { ContributorImageWrapper, getContributor } from "./Card";
+import { palette } from "@guardian/src-foundations";
+import { TableRow } from "../../../layout/Table";
+import { Padding } from "../../../layout/Padding";
+import { Content } from "../../../api";
+import { GridRow, partition } from "../../../layout/Grid";
+import { TableCSS } from "../../../css";
+import { Card as CommentCard } from "./Card";
+
+interface CommentGridProps {
+    content: Content[];
+    salt: string;
+    shouldShowGridImages: boolean;
+}
+
+const tableStyle: TableCSS = {
+    borderCollapse: "collapse",
+    borderSpacing: 0
+};
+
+export const Grid: React.FC<CommentGridProps> = ({
+    content,
+    salt,
+    shouldShowGridImages
+}) => {
+    const rows = partition(content, 2).map((pair, i) => {
+        const hasContributor = pair.find(c => {
+            const tag = getContributor(c);
+            return tag.properties.contributorLargeImagePath;
+        });
+
+        const contributorLeft = (
+            <ContributorImageWrapper content={pair[0]} salt={salt} />
+        );
+
+        const contributorRight = (
+            <ContributorImageWrapper content={pair[1]} salt={salt} />
+        );
+
+        const contributor = (node: React.ReactNode): React.ReactNode => (
+            <TableRow>
+                <td style={{ width: "50%" }}></td>
+                <td style={{ width: "50%" }}>{node}</td>
+            </TableRow>
+        );
+
+        return (
+            <React.Fragment key={i}>
+                <GridRow
+                    left={
+                        <CommentCard
+                            content={pair[0]}
+                            salt={salt}
+                            size={"small"}
+                            shouldShowImage={shouldShowGridImages}
+                        />
+                    }
+                    right={
+                        <CommentCard
+                            content={pair[1]}
+                            salt={salt}
+                            size={"small"}
+                            shouldShowImage={shouldShowGridImages}
+                        />
+                    }
+                    leftStyles={{ backgroundColor: palette.opinion.faded }}
+                    rightStyles={{ backgroundColor: palette.opinion.faded }}
+                />
+                {hasContributor && (
+                    <GridRow
+                        left={contributor(contributorLeft)}
+                        right={contributor(contributorRight)}
+                        leftStyles={{
+                            backgroundColor: palette.opinion.faded,
+                            verticalAlign: "bottom"
+                        }}
+                        rightStyles={{
+                            backgroundColor: palette.opinion.faded,
+                            verticalAlign: "bottom"
+                        }}
+                    />
+                )}
+
+                <Padding px={10} />
+            </React.Fragment>
+        );
+    });
+
+    return <table style={tableStyle}>{rows}</table>;
+};

--- a/src/components/tests/commentC/Card.tsx
+++ b/src/components/tests/commentC/Card.tsx
@@ -41,11 +41,11 @@ const imgProfileStyle: ImageCSS = {
     border: "0"
 };
 
-const tdStyle: TdCSS = {
-    backgroundColor: palette.opinion.faded,
-    borderTop: `2px solid ${palette.opinion.main}`,
-    padding: "0"
-};
+const tdStyle = (isLarge: boolean): TdCSS => ({
+    padding: "0",
+    borderLeft: isLarge ? `1px solid ${palette.opinion.main}` : "none",
+    borderBottom: isLarge ? `1px solid ${palette.opinion.main}` : "none"
+});
 
 const metaWrapperStyle = (size: Size): TdCSS => {
     const rightPad = size === "large" ? "40px" : "10px";
@@ -315,7 +315,7 @@ export const Card: React.FC<Props> = ({
     });
 
     return (
-        <TableRowCell tdStyle={tdStyle}>
+        <TableRowCell tdStyle={tdStyle(size === "large")}>
             <Table>
                 {shouldShowImage && (
                     <RowCell tdStyle={{ padding: "0" }}>

--- a/src/components/tests/commentC/Card.tsx
+++ b/src/components/tests/commentC/Card.tsx
@@ -1,0 +1,379 @@
+import React from "react";
+import { FontCSS, TdCSS, ImageCSS } from "../../../css";
+import { palette } from "@guardian/src-foundations";
+import { Content, Tag } from "../../../api";
+import { formatImage } from "../../../image";
+import { kickerText } from "../../../kicker";
+import sanitizeHtml from "sanitize-html";
+import { Table, RowCell, TableRowCell } from "../../../layout/Table";
+
+type Size = "small" | "large";
+
+const fontSizes = {
+    large: {
+        fontSize: "22px",
+        lineHeight: "26px"
+    },
+    small: {
+        fontSize: "16px",
+        lineHeight: "20px"
+    }
+};
+
+const imgStyle: ImageCSS = {
+    outline: "none",
+    textDecoration: "none",
+    maxWidth: "100%",
+    clear: "both",
+    display: "block",
+    border: "0",
+    width: "100%",
+    fontFamily: "Georgia, serif",
+    color: palette.opinion.main
+};
+
+const imgProfileStyle: ImageCSS = {
+    outline: "none",
+    maxWidth: "100%",
+    fontFamily: "Georgia, serif",
+    color: palette.opinion.main,
+    display: "block",
+    border: "0"
+};
+
+const tdStyle: TdCSS = {
+    backgroundColor: palette.opinion.faded,
+    borderTop: `2px solid ${palette.opinion.main}`,
+    padding: "0"
+};
+
+const metaWrapperStyle = (size: Size): TdCSS => {
+    const rightPad = size === "large" ? "40px" : "10px";
+    return {
+        padding: `3px ${rightPad} 10px 10px`
+    };
+};
+
+const standfirstStyle: TdCSS = {
+    padding: "20px 10px 10px 10px",
+    verticalAlign: "bottom"
+};
+
+const linkStyle: FontCSS = {
+    textDecoration: "none"
+};
+
+const headlineStyle = (size: Size): FontCSS => {
+    return {
+        color: palette.neutral[7],
+        fontFamily: "'GH Guardian Headline', Georgia, serif",
+        fontWeight: 400,
+
+        ...fontSizes[size]
+    };
+};
+
+const spanStyle: FontCSS = {
+    color: palette.neutral[7],
+    fontFamily: "'GH Guardian Headline', Georgia, serif",
+    fontWeight: 400,
+    fontSize: "16px",
+    lineHeight: "20px"
+};
+
+const kickerStyle = (size: Size): FontCSS => {
+    return {
+        color: palette.culture.main,
+        fontFamily: "'GH Guardian Headline', Georgia, serif",
+        fontWeight: 400,
+
+        ...fontSizes[size]
+    };
+};
+
+const bylineStyle = (size: Size): FontCSS => {
+    return {
+        color: palette.opinion.main,
+        fontFamily: "'GH Guardian Headline', Georgia, serif",
+        fontStyle: "italic",
+
+        ...fontSizes[size]
+    };
+};
+
+const quoteIconStyle: ImageCSS = {
+    height: "0.8em",
+    display: "inline-block",
+    border: "0"
+};
+
+const columnStyleLeft: TdCSS = {
+    width: "70%",
+    verticalAlign: "bottom"
+};
+
+const columnStyleRight: TdCSS = {
+    width: "30%",
+    verticalAlign: "bottom"
+};
+
+interface Props {
+    content: Content;
+    salt: string;
+    size: "large" | "small";
+    shouldShowImage: boolean;
+}
+
+const brazeParameter = "?##braze_utm##";
+
+const TrailText: React.FC<{
+    text: string;
+    linkURL: string;
+    size: Size;
+}> = ({ text, linkURL, size }) => {
+    return (
+        <td className="m-pad" style={standfirstStyle}>
+            <a style={linkStyle} href={linkURL}>
+                {" "}
+                <span style={spanStyle}>{text}</span>
+            </a>
+        </td>
+    );
+};
+
+// TODO add alt text
+const ContributorImage: React.FC<{
+    src: string;
+    salt: string;
+    width: number;
+    alt: string;
+}> = ({ src, salt, width, alt }) => {
+    if (!src) {
+        return null;
+    }
+
+    const formattedImage = formatImage(src, salt, width);
+    return (
+        <img
+            width={width}
+            src={formattedImage}
+            alt={alt}
+            style={imgProfileStyle}
+        />
+    );
+};
+
+// TODO make testable, and also separate layout logic from individual components
+// TODO split into SupplementaryMetaLarge and Small
+const SupplementaryMeta: React.FC<{
+    trailText: string;
+    linkURL: string;
+    contributorImageSrc?: string;
+    contributirImageAlt?: string;
+    size: Size;
+    width: number;
+    salt: string;
+}> = ({
+    trailText,
+    contributorImageSrc,
+    linkURL,
+    size,
+    width,
+    contributirImageAlt,
+    salt
+}) => {
+    const contributorImage = (
+        <td style={columnStyleRight}>
+            <ContributorImage
+                width={width}
+                salt={salt}
+                src={contributorImageSrc}
+                alt={contributirImageAlt}
+            />
+        </td>
+    );
+
+    if (trailText && contributorImageSrc) {
+        return (
+            <RowCell>
+                <Table>
+                    <TrailText text={trailText} linkURL={linkURL} size={size} />
+                    {contributorImage}
+                </Table>
+            </RowCell>
+        );
+    } else if (trailText) {
+        return (
+            <tr>
+                <TrailText text={trailText} linkURL={linkURL} size={size} />
+            </tr>
+        );
+    } else if (contributorImageSrc) {
+        return (
+            <RowCell>
+                <Table>
+                    <td style={{ width: "50%" }}></td>
+                    {contributorImage}
+                </Table>
+            </RowCell>
+        );
+    }
+
+    return null;
+};
+
+const Headline: React.FC<{
+    size: Size;
+    linkURL: string;
+    isComment: boolean;
+    kicker: string;
+    headline: string;
+    byline: string;
+}> = ({ size, linkURL, isComment, kicker, headline, byline }) => {
+    return (
+        <tr>
+            <td className="m-pad" style={metaWrapperStyle(size)}>
+                <a style={linkStyle} href={linkURL}>
+                    {kicker && (
+                        <span style={kickerStyle(size)}>{kicker + " / "}</span>
+                    )}
+                    <span style={headlineStyle(size)}>
+                        {isComment && (
+                            <>
+                                <img
+                                    height={"14"}
+                                    style={quoteIconStyle}
+                                    src="https://assets.guim.co.uk/images/email/icons/cc614106682d8de187a64eb222116f3a/quote-opinion.png"
+                                    alt="quote icon"
+                                />{" "}
+                            </>
+                        )}
+
+                        {headline}
+                    </span>
+                    <br />
+                    <span style={bylineStyle(size)}> {byline}</span>
+                </a>
+            </td>
+        </tr>
+    );
+};
+
+const Image: React.FC<{
+    src?: string;
+    linkURL: string;
+    alt: string;
+    width: number;
+}> = ({ src, linkURL, alt, width }) => {
+    if (!src) {
+        return null;
+    }
+
+    return (
+        <a href={linkURL}>
+            <img width={width} style={imgStyle} alt={alt} src={src} />
+        </a>
+    );
+};
+
+export const Card: React.FC<Props> = ({
+    content,
+    salt,
+    size,
+    shouldShowImage
+}) => {
+    const image =
+        content.properties.maybeContent.trail.trailPicture.allImages[0];
+    const formattedImage = formatImage(
+        image.url,
+        salt,
+        size === "large" ? 600 : 300,
+        content.card.starRating
+    );
+
+    const headline = content.header.headline;
+    const byline = content.properties.byline;
+    const webURL = content.properties.webUrl + brazeParameter;
+    const imageURL = formattedImage;
+    const imageAlt = image.fields.altText;
+    const isComment = content.header.isComment;
+
+    const kicker = content.header.kicker
+        ? kickerText(content.header.kicker)
+        : "";
+
+    const contributor = content.properties.maybeContent.tags.tags.find(tag => {
+        return tag.properties.tagType === "Contributor";
+    });
+
+    const profilePic = contributor
+        ? contributor.properties.contributorLargeImagePath
+        : null;
+
+    const trailText = sanitizeHtml(content.card.trailText, {
+        allowedTags: []
+    });
+
+    return (
+        <TableRowCell tdStyle={tdStyle}>
+            <Table>
+                {shouldShowImage && (
+                    <RowCell tdStyle={{ padding: "0" }}>
+                        <Image
+                            src={imageURL}
+                            linkURL={webURL}
+                            alt={imageAlt}
+                            width={size === "large" ? 600 : 294}
+                        />
+                    </RowCell>
+                )}
+
+                <Headline
+                    size={size}
+                    linkURL={webURL}
+                    isComment={isComment}
+                    kicker={kicker}
+                    headline={headline}
+                    byline={byline}
+                />
+
+                {size === "large" && (
+                    <SupplementaryMeta
+                        salt={salt}
+                        trailText={trailText}
+                        linkURL={webURL}
+                        contributorImageSrc={profilePic}
+                        contributirImageAlt={
+                            contributor && contributor.properties.webTitle
+                        }
+                        size={size}
+                        width={size === "large" ? 180 : 147}
+                    />
+                )}
+            </Table>
+        </TableRowCell>
+    );
+};
+
+export const getContributor = (content: Content): Tag => {
+    return content.properties.maybeContent.tags.tags.find(tag => {
+        return tag.properties.tagType === "Contributor";
+    });
+};
+
+export const ContributorImageWrapper: React.FC<{
+    content: Content;
+    salt: string;
+}> = ({ content, salt }) => {
+    const contributor = getContributor(content);
+    const profilePic = contributor.properties.contributorLargeImagePath || null;
+
+    return (
+        <ContributorImage
+            salt={salt}
+            width={147}
+            src={profilePic}
+            alt={contributor.properties.webTitle}
+        />
+    );
+};

--- a/src/components/tests/commentC/Card.tsx
+++ b/src/components/tests/commentC/Card.tsx
@@ -5,7 +5,7 @@ import { Content, Tag } from "../../../api";
 import { formatImage } from "../../../image";
 import { kickerText } from "../../../kicker";
 import sanitizeHtml from "sanitize-html";
-import { Table, RowCell, TableRowCell } from "../../../layout/Table";
+import { Table, RowCell, TableRowCell, TableRow } from "../../../layout/Table";
 
 type Size = "small" | "large";
 
@@ -196,10 +196,10 @@ const SupplementaryMeta: React.FC<{
     if (trailText && contributorImageSrc) {
         return (
             <RowCell>
-                <Table>
+                <TableRow>
                     <TrailText text={trailText} linkURL={linkURL} size={size} />
                     {contributorImage}
-                </Table>
+                </TableRow>
             </RowCell>
         );
     } else if (trailText) {
@@ -211,10 +211,10 @@ const SupplementaryMeta: React.FC<{
     } else if (contributorImageSrc) {
         return (
             <RowCell>
-                <Table>
+                <TableRow>
                     <td style={{ width: "50%" }}></td>
                     {contributorImage}
-                </Table>
+                </TableRow>
             </RowCell>
         );
     }

--- a/src/components/tests/commentC/Collection.tsx
+++ b/src/components/tests/commentC/Collection.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { Collection as ICollection } from "../../../api";
-import { Card as CommentCard } from "././../commentB/Card";
+import { Card as CommentCard } from "././../commentC/Card";
 import { MediaCard } from "../../cards/MediaCard";
 import { Padding } from "../../../layout/Padding";
 import { Heading } from "./../../Heading";
 import { Multiline } from "./../../Multiline";
-import { Grid as CommentGrid } from "../commentB/Grid";
+import { Grid as CommentGrid } from "../commentC/Grid";
 
 const frontIdShouldShowCommentGridImages = (frontId: string): boolean => {
     if (frontId === "email/opinion") {
@@ -32,7 +32,7 @@ export const Collection: React.FC<{
     return (
         <>
             <Multiline />
-            <Heading heading={"VARIANT C!!!"} />
+            <Heading heading={collection.displayName} />
 
             <CommentCard
                 content={c0}
@@ -79,6 +79,28 @@ export const Collection: React.FC<{
                 salt={salt}
                 size={"large"}
                 shouldShowImage={false}
+            />
+        </>
+    );
+};
+
+export const EditorialCollection: React.FC<{
+    collection: ICollection;
+    salt: string;
+}> = ({ collection, salt }) => {
+    const contentOne = collection.backfill[0];
+
+    // TODO
+    return (
+        <>
+            <Multiline />
+            <Heading heading={collection.displayName} />
+
+            <CommentCard
+                content={contentOne}
+                salt={salt}
+                size={"large"}
+                shouldShowImage={true}
             />
         </>
     );

--- a/src/components/tests/commentC/Collection.tsx
+++ b/src/components/tests/commentC/Collection.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { Collection as ICollection } from "../../../api";
+import { Card as CommentCard } from "././../commentB/Card";
+import { MediaCard } from "../../cards/MediaCard";
+import { Padding } from "../../../layout/Padding";
+import { Heading } from "./../../Heading";
+import { Multiline } from "./../../Multiline";
+import { Grid as CommentGrid } from "../commentB/Grid";
+
+const frontIdShouldShowCommentGridImages = (frontId: string): boolean => {
+    if (frontId === "email/opinion") {
+        return false;
+    }
+    return true;
+};
+
+export const Collection: React.FC<{
+    frontId: string;
+    collection: ICollection;
+    salt: string;
+}> = ({ frontId, collection, salt }) => {
+    // TODO handle curated collections
+
+    const c0 = collection.backfill[0];
+    const c1 = collection.backfill[1];
+    const grid_2_5 = collection.backfill.slice(2, 6);
+    const c6 = collection.backfill[6];
+    const grid_7_8 = collection.backfill.slice(7, 9);
+    const c9 = collection.backfill[9];
+
+    // TODO
+    return (
+        <>
+            <Multiline />
+            <Heading heading={"VARIANT C!!!"} />
+
+            <CommentCard
+                content={c0}
+                salt={salt}
+                size={"large"}
+                shouldShowImage={false}
+            />
+            <Padding px={10} />
+
+            <CommentCard
+                content={c1}
+                salt={salt}
+                size={"large"}
+                shouldShowImage={false}
+            />
+            <Padding px={10} />
+
+            <CommentGrid
+                content={grid_2_5}
+                salt={salt}
+                shouldShowGridImages={frontIdShouldShowCommentGridImages(
+                    frontId
+                )}
+            />
+
+            <CommentCard
+                content={c6}
+                salt={salt}
+                size={"large"}
+                shouldShowImage={false}
+            />
+            <Padding px={10} />
+
+            <CommentGrid
+                content={grid_7_8}
+                salt={salt}
+                shouldShowGridImages={frontIdShouldShowCommentGridImages(
+                    frontId
+                )}
+            />
+
+            <CommentCard
+                content={c9}
+                salt={salt}
+                size={"large"}
+                shouldShowImage={false}
+            />
+        </>
+    );
+};

--- a/src/components/tests/commentC/Grid.tsx
+++ b/src/components/tests/commentC/Grid.tsx
@@ -116,5 +116,5 @@ export const Grid: React.FC<CommentGridProps> = ({
         );
     });
 
-    return <table style={tableStyle}>{rows}</table>;
+    return <TableRowCell>{rows}</TableRowCell>;
 };

--- a/src/components/tests/commentC/Grid.tsx
+++ b/src/components/tests/commentC/Grid.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { ContributorImageWrapper, getContributor } from "./Card";
 import { palette } from "@guardian/src-foundations";
-import { TableRow } from "../../../layout/Table";
+import { TableRow, TableRowCell } from "../../../layout/Table";
 import { Padding } from "../../../layout/Padding";
 import { Content } from "../../../api";
 import { GridRow, partition } from "../../../layout/Grid";
@@ -64,20 +64,51 @@ export const Grid: React.FC<CommentGridProps> = ({
                             shouldShowImage={shouldShowGridImages}
                         />
                     }
-                    leftStyles={{ backgroundColor: palette.opinion.faded }}
-                    rightStyles={{ backgroundColor: palette.opinion.faded }}
+                    leftStyles={{
+                        backgroundColor: palette.neutral[100],
+                        verticalAlign: "bottom",
+                        borderLeft: `1px solid ${palette.opinion.main}`
+                    }}
+                    rightStyles={{
+                        backgroundColor: palette.neutral[100],
+                        verticalAlign: "bottom",
+                        borderLeft: `1px solid ${palette.opinion.main}`
+                    }}
                 />
-                {hasContributor && (
+                {hasContributor ? (
                     <GridRow
                         left={contributor(contributorLeft)}
                         right={contributor(contributorRight)}
                         leftStyles={{
-                            backgroundColor: palette.opinion.faded,
-                            verticalAlign: "bottom"
+                            backgroundColor: palette.neutral[100],
+                            verticalAlign: "bottom",
+                            borderLeft: `1px solid ${palette.opinion.main}`,
+                            borderBottom: `1px solid ${palette.opinion.main}`
                         }}
                         rightStyles={{
-                            backgroundColor: palette.opinion.faded,
-                            verticalAlign: "bottom"
+                            backgroundColor: palette.neutral[100],
+                            verticalAlign: "bottom",
+                            borderLeft: `1px solid ${palette.opinion.main}`,
+                            borderBottom: `1px solid ${palette.opinion.main}`
+                        }}
+                    />
+                ) : (
+                    <GridRow
+                        left="&nbsp;"
+                        right="&nbsp;"
+                        leftStyles={{
+                            backgroundColor: palette.neutral[100],
+                            verticalAlign: "bottom",
+                            borderLeft: `1px solid ${palette.opinion.main}`,
+                            borderBottom: `1px solid ${palette.opinion.main}`,
+                            lineHeight: "0"
+                        }}
+                        rightStyles={{
+                            backgroundColor: palette.neutral[100],
+                            verticalAlign: "bottom",
+                            borderLeft: `1px solid ${palette.opinion.main}`,
+                            borderBottom: `1px solid ${palette.opinion.main}`,
+                            lineHeight: "0"
                         }}
                     />
                 )}

--- a/src/components/tests/commentC/Grid.tsx
+++ b/src/components/tests/commentC/Grid.tsx
@@ -66,12 +66,10 @@ export const Grid: React.FC<CommentGridProps> = ({
                     }
                     leftStyles={{
                         backgroundColor: palette.neutral[100],
-                        verticalAlign: "bottom",
                         borderLeft: `1px solid ${palette.opinion.main}`
                     }}
                     rightStyles={{
                         backgroundColor: palette.neutral[100],
-                        verticalAlign: "bottom",
                         borderLeft: `1px solid ${palette.opinion.main}`
                     }}
                 />

--- a/src/components/tests/commentC/Grid.tsx
+++ b/src/components/tests/commentC/Grid.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { ContributorImageWrapper, getContributor } from "./Card";
+import { palette } from "@guardian/src-foundations";
+import { TableRow } from "../../../layout/Table";
+import { Padding } from "../../../layout/Padding";
+import { Content } from "../../../api";
+import { GridRow, partition } from "../../../layout/Grid";
+import { TableCSS } from "../../../css";
+import { Card as CommentCard } from "./Card";
+
+interface CommentGridProps {
+    content: Content[];
+    salt: string;
+    shouldShowGridImages: boolean;
+}
+
+const tableStyle: TableCSS = {
+    borderCollapse: "collapse",
+    borderSpacing: 0
+};
+
+export const Grid: React.FC<CommentGridProps> = ({
+    content,
+    salt,
+    shouldShowGridImages
+}) => {
+    const rows = partition(content, 2).map((pair, i) => {
+        const hasContributor = pair.find(c => {
+            const tag = getContributor(c);
+            return tag.properties.contributorLargeImagePath;
+        });
+
+        const contributorLeft = (
+            <ContributorImageWrapper content={pair[0]} salt={salt} />
+        );
+
+        const contributorRight = (
+            <ContributorImageWrapper content={pair[1]} salt={salt} />
+        );
+
+        const contributor = (node: React.ReactNode): React.ReactNode => (
+            <TableRow>
+                <td style={{ width: "50%" }}></td>
+                <td style={{ width: "50%" }}>{node}</td>
+            </TableRow>
+        );
+
+        return (
+            <React.Fragment key={i}>
+                <GridRow
+                    left={
+                        <CommentCard
+                            content={pair[0]}
+                            salt={salt}
+                            size={"small"}
+                            shouldShowImage={shouldShowGridImages}
+                        />
+                    }
+                    right={
+                        <CommentCard
+                            content={pair[1]}
+                            salt={salt}
+                            size={"small"}
+                            shouldShowImage={shouldShowGridImages}
+                        />
+                    }
+                    leftStyles={{ backgroundColor: palette.opinion.faded }}
+                    rightStyles={{ backgroundColor: palette.opinion.faded }}
+                />
+                {hasContributor && (
+                    <GridRow
+                        left={contributor(contributorLeft)}
+                        right={contributor(contributorRight)}
+                        leftStyles={{
+                            backgroundColor: palette.opinion.faded,
+                            verticalAlign: "bottom"
+                        }}
+                        rightStyles={{
+                            backgroundColor: palette.opinion.faded,
+                            verticalAlign: "bottom"
+                        }}
+                    />
+                )}
+
+                <Padding px={10} />
+            </React.Fragment>
+        );
+    });
+
+    return <table style={tableStyle}>{rows}</table>;
+};

--- a/src/css.ts
+++ b/src/css.ts
@@ -36,6 +36,8 @@ export interface TdCSS extends FontCSS {
     paddingBottom?: string;
     paddingTop?: string;
     borderTop?: string;
+    borderLeft?: string;
+    borderBottom?: string;
     backgroundColor?: string;
     width?: string;
     verticalAlign?: "bottom" | "top";

--- a/src/layout/Grid.tsx
+++ b/src/layout/Grid.tsx
@@ -13,7 +13,8 @@ const tableStyle: TableCSS = {
 };
 
 const gutterStyle: TdCSS = {
-    width: "2%"
+    width: "2%",
+    lineHeight: "0"
 };
 
 type VAlign = "top" | "bottom";
@@ -21,16 +22,22 @@ type VAlign = "top" | "bottom";
 interface RowStyle {
     backgroundColor: string;
     verticalAlign?: VAlign;
+    borderBottom?: string;
+    borderLeft?: string;
+    lineHeight?: string;
 }
 
 const colStyle = (styles: RowStyle): TdCSS => ({
     width: "49%",
     backgroundColor: styles.backgroundColor,
-    verticalAlign: styles.verticalAlign || "top"
+    verticalAlign: styles.verticalAlign || "top",
+    borderBottom: styles.borderBottom || "none",
+    borderLeft: styles.borderLeft || "none",
+    lineHeight: styles.lineHeight || "inherit"
 });
 
 const defaultRowStyles: RowStyle = {
-    backgroundColor: palette.culture.faded
+    backgroundColor: palette.neutral[100]
 };
 
 export const GridRow: React.FC<{

--- a/src/layout/Grid.tsx
+++ b/src/layout/Grid.tsx
@@ -2,15 +2,10 @@ import React from "react";
 import { Content } from "../api";
 import { Card } from "../components/cards/Card";
 import { LinkCard } from "../components/cards/LinkCard";
-import { TdCSS, TableCSS } from "../css";
+import { TdCSS } from "../css";
 import { palette } from "@guardian/src-foundations";
-import { TableRow } from "./Table";
+import { TableRow, TableRowCell } from "./Table";
 import { Padding } from "./Padding";
-
-const tableStyle: TableCSS = {
-    borderCollapse: "collapse",
-    borderSpacing: 0
-};
 
 const gutterStyle: TdCSS = {
     width: "2%",
@@ -92,7 +87,7 @@ export const DefaultGrid: React.FC<DefaultGridProps> = ({ content, salt }) => {
         </React.Fragment>
     ));
 
-    return <table style={tableStyle}>{rows}</table>;
+    return <TableRowCell>{rows}</TableRowCell>;
 };
 
 // TODO really should accept a React element so that it doesn't have to know
@@ -119,5 +114,5 @@ export const LinkGrid: React.FC<DefaultGridProps> = ({ content, salt }) => {
         </React.Fragment>
     ));
 
-    return <table style={tableStyle}>{rows}</table>;
+    return <TableRowCell>{rows}</TableRowCell>;
 };

--- a/src/layout/Grid.tsx
+++ b/src/layout/Grid.tsx
@@ -1,11 +1,6 @@
 import React from "react";
 import { Content } from "../api";
 import { Card } from "../components/cards/Card";
-import {
-    ContributorImageWrapper,
-    CommentCard,
-    getContributor
-} from "../components/cards/CommentCard";
 import { LinkCard } from "../components/cards/LinkCard";
 import { TdCSS, TableCSS } from "../css";
 import { palette } from "@guardian/src-foundations";
@@ -38,7 +33,7 @@ const defaultRowStyles: RowStyle = {
     backgroundColor: palette.culture.faded
 };
 
-const GridRow: React.FC<{
+export const GridRow: React.FC<{
     left: React.ReactNode;
     right: React.ReactNode;
     leftStyles?: RowStyle;
@@ -56,7 +51,7 @@ const GridRow: React.FC<{
     </TableRow>
 );
 
-function partition<T>(seq: T[], n: number): T[][] {
+export function partition<T>(seq: T[], n: number): T[][] {
     // split into groups of two
     // return half-width cards
     const groups = [];
@@ -70,11 +65,6 @@ function partition<T>(seq: T[], n: number): T[][] {
 interface DefaultGridProps {
     content: Content[];
     salt: string;
-}
-interface CommentGridProps {
-    content: Content[];
-    salt: string;
-    shouldShowGridImages: boolean;
 }
 
 // TODO really should accept a React element so that it doesn't have to know
@@ -121,77 +111,6 @@ export const LinkGrid: React.FC<DefaultGridProps> = ({ content, salt }) => {
             <Padding px={10} />
         </React.Fragment>
     ));
-
-    return <table style={tableStyle}>{rows}</table>;
-};
-
-export const CommentGrid: React.FC<CommentGridProps> = ({
-    content,
-    salt,
-    shouldShowGridImages
-}) => {
-    const rows = partition(content, 2).map((pair, i) => {
-        const hasContributor = pair.find(content => {
-            const contributor = getContributor(content);
-            return contributor.properties.contributorLargeImagePath;
-        });
-
-        const contributorLeft = (
-            <ContributorImageWrapper content={pair[0]} salt={salt} />
-        );
-
-        const contributorRight = (
-            <ContributorImageWrapper content={pair[1]} salt={salt} />
-        );
-
-        const contributor = (node: React.ReactNode): React.ReactNode => (
-            <TableRow>
-                <td style={{ width: "50%" }}></td>
-                <td style={{ width: "50%" }}>{node}</td>
-            </TableRow>
-        );
-
-        return (
-            <React.Fragment key={i}>
-                <GridRow
-                    left={
-                        <CommentCard
-                            content={pair[0]}
-                            salt={salt}
-                            size={"small"}
-                            shouldShowImage={shouldShowGridImages}
-                        />
-                    }
-                    right={
-                        <CommentCard
-                            content={pair[1]}
-                            salt={salt}
-                            size={"small"}
-                            shouldShowImage={shouldShowGridImages}
-                        />
-                    }
-                    leftStyles={{ backgroundColor: palette.opinion.faded }}
-                    rightStyles={{ backgroundColor: palette.opinion.faded }}
-                />
-                {hasContributor && (
-                    <GridRow
-                        left={contributor(contributorLeft)}
-                        right={contributor(contributorRight)}
-                        leftStyles={{
-                            backgroundColor: palette.opinion.faded,
-                            verticalAlign: "bottom"
-                        }}
-                        rightStyles={{
-                            backgroundColor: palette.opinion.faded,
-                            verticalAlign: "bottom"
-                        }}
-                    />
-                )}
-
-                <Padding px={10} />
-            </React.Fragment>
-        );
-    });
 
     return <table style={tableStyle}>{rows}</table>;
 };

--- a/src/layout/Grid.tsx
+++ b/src/layout/Grid.tsx
@@ -81,6 +81,12 @@ export const DefaultGrid: React.FC<DefaultGridProps> = ({ content, salt }) => {
                         <Card content={pair[1]} salt={salt} size={"small"} />
                     ) : null
                 }
+                leftStyles={{
+                    backgroundColor: palette.culture.faded
+                }}
+                rightStyles={{
+                    backgroundColor: palette.culture.faded
+                }}
             />
 
             <Padding px={10} />

--- a/src/layout/Padding.tsx
+++ b/src/layout/Padding.tsx
@@ -10,7 +10,7 @@ const tableStyle: TableCSS = {
 export const Padding: React.FC<{ px: number }> = ({ px }) => (
     <table style={tableStyle}>
         <tr>
-            <td style={{ paddingTop: `${px}px` }}></td>
+            <td style={{ lineHeight: "0", paddingTop: `${px}px` }}>&nbsp;</td>
         </tr>
     </table>
 );

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,7 +20,7 @@ const imageSalt: Promise<string> = process.env.IMAGE_SALT
 app.get(
     "/:path.json",
     asyncHandler(async (req, res) => {
-        const email = await getFront(req.params.path);
+        const email = await getFront(req.params.path, req.query.variant);
         res.send({ body: email });
     })
 );
@@ -35,7 +35,7 @@ app.get(
             return;
         }
 
-        const email = await getFront(req.params.path);
+        const email = await getFront(req.params.path, req.query.variant);
         res.send(email);
     })
 );
@@ -59,10 +59,10 @@ app.get(
     })
 );
 
-const getFront = async (path: string): Promise<string> => {
+const getFront = async (path: string, variant?: string): Promise<string> => {
     const salt = await imageSalt;
     const front = await api.get(path);
-    return Email(front, salt);
+    return Email(front, salt, variant);
 };
 
 const getTextFront = async (path: string): Promise<string> => {


### PR DESCRIPTION
We've implemented this:

<img width="756" alt="Screenshot 2019-11-20 at 15 52 04" src="https://user-images.githubusercontent.com/858402/69254207-c88aaa80-0bad-11ea-940c-b4273dfeb679.png">

and also fixed some markup issues.

There are still a couple of TODOs:

* arrow image location
* hide jobs section
* colour of editorial collection