### PR TITLE
Setting padding 0 on Opinion grid/card with author cutout

### DIFF
--- a/src/components/tests/commentB/Card.tsx
+++ b/src/components/tests/commentB/Card.tsx
@@ -114,7 +114,8 @@ const columnStyleLeft: TdCSS = {
 
 const columnStyleRight: TdCSS = {
     width: "30%",
-    verticalAlign: "bottom"
+    verticalAlign: "bottom",
+    padding: "0"
 };
 
 interface Props {

--- a/src/components/tests/commentB/Grid.tsx
+++ b/src/components/tests/commentB/Grid.tsx
@@ -35,8 +35,8 @@ export const Grid: React.FC<CommentGridProps> = ({
 
         const contributor = (node: React.ReactNode): React.ReactNode => (
             <TableRow>
-                <td style={{ width: "50%" }}></td>
-                <td style={{ width: "50%" }}>{node}</td>
+                <td style={{ width: "50%", padding: "0" }}></td>
+                <td style={{ width: "50%", padding: "0" }}>{node}</td>
             </TableRow>
         );
 

--- a/src/components/tests/commentC/Card.tsx
+++ b/src/components/tests/commentC/Card.tsx
@@ -114,7 +114,8 @@ const columnStyleLeft: TdCSS = {
 
 const columnStyleRight: TdCSS = {
     width: "30%",
-    verticalAlign: "bottom"
+    verticalAlign: "bottom",
+    padding: "0"
 };
 
 interface Props {

--- a/src/components/tests/commentC/Grid.tsx
+++ b/src/components/tests/commentC/Grid.tsx
@@ -41,8 +41,8 @@ export const Grid: React.FC<CommentGridProps> = ({
 
         const contributor = (node: React.ReactNode): React.ReactNode => (
             <TableRow>
-                <td style={{ width: "50%" }}></td>
-                <td style={{ width: "50%" }}>{node}</td>
+                <td style={{ width: "50%", padding: "0" }}></td>
+                <td style={{ width: "50%", padding: "0" }}>{node}</td>
             </TableRow>
         );
 


### PR DESCRIPTION
This fixes an issue on some email clients where there's an unwanted white space between the author cutout and the edge of the cell it sits in.

Same change on both variants of Opinion (in Grid and Card itself).