### PR TITLE
Ignores Jobs/Masterclasses collection in Opinion emails

### DIFF
--- a/src/components/Collections.tsx
+++ b/src/components/Collections.tsx
@@ -69,8 +69,14 @@ export const Collections: React.FC<{
         const content = [].concat(collection.backfill, collection.curated); // TODO support curated too
         const designType = getDesignType(frontId, content);
 
-        if (collection.displayName === "Save 50% for three months") {
-            return null; // ignore the jobs collection for now
+        // Ignore the jobs/masterclasses collection for now
+        // The collection displayName changes over time and isn't reliable enough for this condition
+        // So intead, we use a different, also unreliable approach of checking for a collection
+        // with one and only one curated item.
+        // TODO: refactor this condition to be more reliable and last long term
+        // Or otherwise remove condition and accept the jobs/masterclasses collection
+        if (frontId === "email/opinion" && collection.curated.length === 1) {
+            return null;
         }
 
         switch (designType) {


### PR DESCRIPTION
## What does this change?
Tweaks the condition used to hide the 'Jobs' collection in Opinion so it uses something reasonably reliable other than `displayName`, which will change often during the Black Friday/Cyber Monday period.

## Why?
Because the editors changed the display name for this collection so the existing condition was no longer able to pick it up, causing it to be rendered (unwanted behaviour) with a design we didn't expect (double unwanted).

## Link to supporting Trello card
https://trello.com/c/tiYGdgee/67-resolve-design-issue-with-guardian-masterclasses-in-opinion-vars-b-c