### PR TITLE
White quote icon added in to follow Media Briefing C design

### DIFF
--- a/src/components/cards/OverlayCard.tsx
+++ b/src/components/cards/OverlayCard.tsx
@@ -162,7 +162,7 @@ export const OverlayCard: React.FC<Props> = ({
                                                 <img
                                                     height={"14"}
                                                     style={quoteIconStyle}
-                                                    src="https://assets.guim.co.uk/images/email/icons/9682728db696148fd5a6b149e556df8c/quote-culture.png"
+                                                    src="https://cdn.braze.eu/appboy/communication/assets/image_assets/images/5de534049ae16859519012fa/original.png?1575302148"
                                                     alt="quote icon"
                                                 />{" "}
                                             </>


### PR DESCRIPTION
## What does this change?
It adds a new white quote icon.
## Why?
To support the new Media Briefing design.
## Link to supporting Trello card
https://trello.com/c/UBQJPTSV/77-add-the-white-quote-to-support-media-briefing-c-design
Before:
![Screen Shot 2019-12-02 at 11 22 28](https://user-images.githubusercontent.com/47107438/69974828-ee08a400-151d-11ea-88eb-9c8b04c34edd.png)
After:
![Screen Shot 2019-12-02 at 16 09 09](https://user-images.githubusercontent.com/47107438/69977560-eef00480-1522-11ea-8c14-aab84f4fe2f6.png)