### PR TITLE
Use headline as image alt text across all cards

### DIFF
--- a/src/components/cards/CommentCardB.tsx
+++ b/src/components/cards/CommentCardB.tsx
@@ -207,7 +207,7 @@ export const CommentCardB: React.FC<Props> = ({
     const byline = content.properties.byline;
     const webURL = content.properties.webUrl + brazeParameter;
     const imageURL = formattedImage;
-    const imageAlt = image.fields.altText;
+    const imageAlt = content.header.headline;
     const showQuotation = content.header.isComment;
 
     const contributor = content.properties.maybeContent.tags.tags.find(tag => {

--- a/src/components/cards/CommentCardC.tsx
+++ b/src/components/cards/CommentCardC.tsx
@@ -228,7 +228,7 @@ export const CommentCardC: React.FC<Props> = ({
     const byline = content.properties.byline;
     const webURL = content.properties.webUrl + brazeParameter;
     const imageURL = formattedImage;
-    const imageAlt = image.fields.altText;
+    const imageAlt = content.header.headline;
     const showQuotation = content.header.isComment;
 
     const contributor = content.properties.maybeContent.tags.tags.find(tag => {

--- a/src/components/cards/DefaultCard.tsx
+++ b/src/components/cards/DefaultCard.tsx
@@ -65,7 +65,7 @@ export const DefaultCard: React.FC<Props> = ({ content, salt, size }) => {
     const byline = content.properties.byline;
     const webURL = content.properties.webUrl + brazeParameter;
     const imageURL = formattedImage;
-    const imageAlt = image.fields.altText;
+    const imageAlt = content.header.headline;
     const showQuotation = content.display.showQuotedHeadline;
 
     const pillar = content.properties.maybeContent

--- a/src/components/cards/DescriptiveCard.tsx
+++ b/src/components/cards/DescriptiveCard.tsx
@@ -108,7 +108,7 @@ export const DescriptiveCard: React.FC<Props> = ({
     const { trailText } = content.card;
     const webURL = content.properties.webUrl + brazeParameter;
     const imageURL = formattedImage;
-    const imageAlt = image.fields.altText;
+    const imageAlt = content.header.headline;
     const showQuotation = content.display.showQuotedHeadline;
 
     const kicker = content.header.kicker

--- a/src/components/cards/MediaCardB.tsx
+++ b/src/components/cards/MediaCardB.tsx
@@ -68,7 +68,7 @@ export const MediaCardB: React.FC<Props> = ({ content, salt }) => {
     const headline = content.header.headline;
     const webURL = content.properties.webUrl + brazeParameter;
     const imageURL = formattedImage;
-    const imageAlt = image.fields.altText;
+    const imageAlt = content.header.headline;
 
     return (
         <TableRowCell tdStyle={tdStyle}>

--- a/src/components/cards/MediaCardC.tsx
+++ b/src/components/cards/MediaCardC.tsx
@@ -69,7 +69,7 @@ export const MediaCardC: React.FC<Props> = ({ content, salt }) => {
     const headline = content.header.headline;
     const webURL = content.properties.webUrl + brazeParameter;
     const imageURL = formattedImage;
-    const imageAlt = image.fields.altText;
+    const imageAlt = content.header.headline;
 
     return (
         <TableRowCell tdStyle={tdStyle}>

--- a/src/components/cards/OverlayCard.tsx
+++ b/src/components/cards/OverlayCard.tsx
@@ -93,7 +93,7 @@ export const OverlayCard: React.FC<Props> = ({
 
     const webURL = content.properties.webUrl + brazeParameter;
     const imageURL = formattedImage;
-    const imageAlt = image.fields.altText;
+    const imageAlt = content.header.headline;
     const showQuotation = content.display.showQuotedHeadline;
 
     const kicker = content.header.kicker


### PR DESCRIPTION
## What does this change?
Switches to using the content headline as alt text for the card image, across all cards.

## Why?
Because we've discovered that using the image alt text in the API may cause some email clients to break.