### PR TITLE
Adds Image component & cleans lots of CSS

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -1,16 +1,6 @@
 import React from "react";
-import { ImageCSS } from "../css";
 import { TableRowCell } from "../layout/Table";
-
-const imgStyle: ImageCSS = {
-    outline: "none",
-    textDecoration: "none",
-    maxWidth: "100%",
-    clear: "both",
-    display: "block",
-    border: "0",
-    width: "100%"
-};
+import { Image } from "./Image";
 
 export const Banner: React.FC<{ frontId: string }> = ({ frontId }) => {
     const banners: { [key in string]: string } = {
@@ -33,12 +23,7 @@ export const Banner: React.FC<{ frontId: string }> = ({ frontId }) => {
 
     return (
         <TableRowCell tdStyle={{ padding: "0" }}>
-            <img
-                width="600"
-                src={bannerSrc}
-                alt={bannerAltText}
-                style={imgStyle}
-            ></img>
+            <Image width={600} src={bannerSrc} alt={bannerAltText} />
         </TableRowCell>
     );
 };

--- a/src/components/Image.tsx
+++ b/src/components/Image.tsx
@@ -34,7 +34,6 @@ const defaultImageStyles: ImageCSS = {
     display: "block",
     clear: "both",
     border: "0"
-    // border: "2px solid red"
 };
 
 export const Image: React.FC<Props> = ({
@@ -46,15 +45,18 @@ export const Image: React.FC<Props> = ({
     linkTo,
     pillar
 }) => {
-    // Merge prop styles into default styles
+    // If a pillar has been passed in, add its colour to the image styles
+    // Defaults to dark grey when no pillar available
     const pillarColour =
         pillar && pillarProps[pillar]
-            ? { color: pillarProps[pillar].colour }
-            : { color: palette.neutral[7] };
+            ? pillarProps[pillar].colour
+            : palette.neutral[7];
+    const imagePillarStyles = { color: pillarColour };
 
+    // Combine all image styles allowing styles passed in via props to take precedence over default styles
     const imageStyles = {
         ...defaultImageStyles,
-        ...pillarColour,
+        ...imagePillarStyles,
         ...extraStyles
     };
 

--- a/src/components/Image.tsx
+++ b/src/components/Image.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { palette } from "@guardian/src-foundations";
+import { ImageCSS } from "../css";
+import { Pillar } from "../api";
+
+import { pillarProps } from "../utils/pillarProps";
+
+const ImageElement: React.FC<{
+    src: string;
+    alt: string;
+    width?: number;
+    height?: number;
+    style: ImageCSS;
+}> = ({ src, alt, width, height, style }) => (
+    <img src={src} alt={alt} width={width} height={height} style={style} />
+);
+
+interface Props {
+    src: string;
+    alt: string;
+    width?: number;
+    height?: number;
+    extraStyles?: ImageCSS;
+    linkTo?: string;
+    pillar?: Pillar;
+}
+
+const defaultImageStyles: ImageCSS = {
+    fontFamily: "Georgia, serif",
+    textDecoration: "none",
+    width: "100%",
+    maxWidth: "100%",
+    outline: "none",
+    display: "block",
+    clear: "both",
+    border: "0"
+    // border: "2px solid red"
+};
+
+export const Image: React.FC<Props> = ({
+    src,
+    alt,
+    width,
+    height,
+    extraStyles,
+    linkTo,
+    pillar
+}) => {
+    // Merge prop styles into default styles
+    const pillarColour =
+        pillar && pillarProps[pillar]
+            ? { color: pillarProps[pillar].colour }
+            : { color: palette.neutral[7] };
+
+    const imageStyles = {
+        ...defaultImageStyles,
+        ...pillarColour,
+        ...extraStyles
+    };
+
+    if (linkTo) {
+        return (
+            <a href={linkTo}>
+                <ImageElement
+                    src={src}
+                    alt={alt}
+                    width={width}
+                    height={height}
+                    style={imageStyles}
+                />
+            </a>
+        );
+    }
+    return (
+        <ImageElement
+            src={src}
+            alt={alt}
+            width={width}
+            height={height}
+            style={imageStyles}
+        />
+    );
+};

--- a/src/components/cards/CommentCardB.tsx
+++ b/src/components/cards/CommentCardB.tsx
@@ -1,34 +1,14 @@
 import React from "react";
-import { FontCSS, TdCSS, ImageCSS } from "../../css";
+import { FontCSS, TdCSS } from "../../css";
 import { palette } from "@guardian/src-foundations";
 import { Content, Tag } from "../../api";
 import { formatImage } from "../../image";
 import sanitizeHtml from "sanitize-html";
 import { Table, RowCell, TableRowCell, TableRow } from "../../layout/Table";
 import { Headline } from "../../components/Headline";
+import { Image } from "../../components/Image";
 
 type Size = "small" | "large";
-
-const imgStyle: ImageCSS = {
-    outline: "none",
-    textDecoration: "none",
-    maxWidth: "100%",
-    clear: "both",
-    display: "block",
-    border: "0",
-    width: "100%",
-    fontFamily: "Georgia, serif",
-    color: palette.opinion.main
-};
-
-const imgProfileStyle: ImageCSS = {
-    outline: "none",
-    maxWidth: "100%",
-    fontFamily: "Georgia, serif",
-    color: palette.opinion.main,
-    display: "block",
-    border: "0"
-};
 
 const tdStyle: TdCSS = {
     backgroundColor: palette.opinion.faded,
@@ -103,12 +83,7 @@ const ContributorImage: React.FC<{
 
     const formattedImage = formatImage(src, salt, width);
     return (
-        <img
-            width={width}
-            src={formattedImage}
-            alt={alt}
-            style={imgProfileStyle}
-        />
+        <Image src={formattedImage} width={width} alt={alt} pillar="Opinion" />
     );
 };
 
@@ -171,23 +146,6 @@ const SupplementaryMeta: React.FC<{
     return null;
 };
 
-const Image: React.FC<{
-    src?: string;
-    linkURL: string;
-    alt: string;
-    width: number;
-}> = ({ src, linkURL, alt, width }) => {
-    if (!src) {
-        return null;
-    }
-
-    return (
-        <a href={linkURL}>
-            <img width={width} style={imgStyle} alt={alt} src={src} />
-        </a>
-    );
-};
-
 export const CommentCardB: React.FC<Props> = ({
     content,
     salt,
@@ -229,9 +187,10 @@ export const CommentCardB: React.FC<Props> = ({
                     <RowCell tdStyle={{ padding: "0" }}>
                         <Image
                             src={imageURL}
-                            linkURL={webURL}
+                            linkTo={webURL}
                             alt={imageAlt}
                             width={size === "large" ? 600 : 294}
+                            pillar="Opinion"
                         />
                     </RowCell>
                 )}

--- a/src/components/cards/CommentCardC.tsx
+++ b/src/components/cards/CommentCardC.tsx
@@ -6,39 +6,12 @@ import { formatImage } from "../../image";
 import sanitizeHtml from "sanitize-html";
 import { Table, RowCell, TableRowCell, TableRow } from "../../layout/Table";
 import { Headline } from "../../components/Headline";
+import { Image } from "../../components/Image";
 
 type Size = "small" | "large";
 
-const fontSizes = {
-    large: {
-        fontSize: "22px",
-        lineHeight: "26px"
-    },
-    small: {
-        fontSize: "16px",
-        lineHeight: "20px"
-    }
-};
-
 const imgStyle: ImageCSS = {
-    outline: "none",
-    textDecoration: "none",
-    maxWidth: "100%",
-    clear: "both",
-    display: "block",
-    border: "0",
-    width: "100%",
-    fontFamily: "Georgia, serif",
     color: palette.opinion.main
-};
-
-const imgProfileStyle: ImageCSS = {
-    outline: "none",
-    maxWidth: "100%",
-    fontFamily: "Georgia, serif",
-    color: palette.opinion.main,
-    display: "block",
-    border: "0"
 };
 
 const tdStyle = (isLarge: boolean): TdCSS => ({
@@ -69,16 +42,6 @@ const spanStyle: FontCSS = {
     fontWeight: 400,
     fontSize: "16px",
     lineHeight: "20px"
-};
-
-const bylineStyle = (size: Size): FontCSS => {
-    return {
-        color: palette.opinion.main,
-        fontFamily: "'GH Guardian Headline', Georgia, serif",
-        fontStyle: "italic",
-
-        ...fontSizes[size]
-    };
 };
 
 const columnStyleRight: TdCSS = {
@@ -124,12 +87,7 @@ const ContributorImage: React.FC<{
 
     const formattedImage = formatImage(src, salt, width);
     return (
-        <img
-            width={width}
-            src={formattedImage}
-            alt={alt}
-            style={imgProfileStyle}
-        />
+        <Image src={formattedImage} width={width} alt={alt} pillar="Opinion" />
     );
 };
 
@@ -192,23 +150,6 @@ const SupplementaryMeta: React.FC<{
     return null;
 };
 
-const Image: React.FC<{
-    src?: string;
-    linkURL: string;
-    alt: string;
-    width: number;
-}> = ({ src, linkURL, alt, width }) => {
-    if (!src) {
-        return null;
-    }
-
-    return (
-        <a href={linkURL}>
-            <img width={width} style={imgStyle} alt={alt} src={src} />
-        </a>
-    );
-};
-
 export const CommentCardC: React.FC<Props> = ({
     content,
     salt,
@@ -250,9 +191,10 @@ export const CommentCardC: React.FC<Props> = ({
                     <RowCell tdStyle={{ padding: "0" }}>
                         <Image
                             src={imageURL}
-                            linkURL={webURL}
+                            linkTo={webURL}
                             alt={imageAlt}
                             width={size === "large" ? 599 : 294}
+                            pillar="Opinion"
                         />
                     </RowCell>
                 )}

--- a/src/components/cards/DefaultCard.tsx
+++ b/src/components/cards/DefaultCard.tsx
@@ -1,24 +1,13 @@
 import React from "react";
-import { TdCSS, TableCSS, ImageCSS } from "../../css";
+import { TdCSS, TableCSS } from "../../css";
 import { palette } from "@guardian/src-foundations";
 import { Content } from "../../api";
 import { formatImage } from "../../image";
 import { kickerText } from "../../kicker";
 import { Headline } from "../../components/Headline";
+import { Image } from "../../components/Image";
 
 type Size = "small" | "large";
-
-const imgStyle: ImageCSS = {
-    outline: "none",
-    textDecoration: "none",
-    maxWidth: "100%",
-    clear: "both",
-    display: "block",
-    border: "0",
-    width: "100%",
-    fontFamily: "Georgia, serif",
-    color: palette.culture.main
-};
 
 const tableStyle: TableCSS = {
     borderSpacing: 0,
@@ -84,16 +73,13 @@ export const DefaultCard: React.FC<Props> = ({ content, salt, size }) => {
                         {imageURL && (
                             <tr>
                                 <td style={{ padding: 0 }}>
-                                    <a href={webURL}>
-                                        <img
-                                            width={
-                                                size === "large" ? "600" : "294"
-                                            }
-                                            style={imgStyle}
-                                            alt={imageAlt}
-                                            src={imageURL}
-                                        />
-                                    </a>
+                                    <Image
+                                        src={imageURL}
+                                        alt={imageAlt}
+                                        width={size === "large" ? 600 : 294}
+                                        pillar={pillar}
+                                        linkTo={webURL}
+                                    />
                                 </td>
                             </tr>
                         )}

--- a/src/components/cards/DescriptiveCard.tsx
+++ b/src/components/cards/DescriptiveCard.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import sanitizeHtml from "sanitize-html";
-import { FontCSS, TdCSS, TableCSS, ImageCSS } from "../../css";
+import { FontCSS, TdCSS, TableCSS } from "../../css";
 import { sanitizeOptions } from "../../utils/sanitizeOptions";
 import { ContinueButton } from "../buttons/ContinueButton";
 import { palette } from "@guardian/src-foundations";
@@ -8,6 +8,7 @@ import { Content } from "../../api";
 import { formatImage } from "../../image";
 import { kickerText } from "../../kicker";
 import { Headline } from "../../components/Headline";
+import { Image } from "../../components/Image";
 
 const fontFamily = {
     headline: {
@@ -27,18 +28,6 @@ const fontSizes = {
         fontSize: "16px",
         lineHeight: "20px"
     }
-};
-
-const imgStyle: ImageCSS = {
-    outline: "none",
-    textDecoration: "none",
-    maxWidth: "100%",
-    clear: "both",
-    display: "block",
-    border: "0",
-    width: "100%",
-    fontFamily: "Georgia, serif",
-    color: palette.culture.main
 };
 
 const tableStyle: TableCSS = {
@@ -155,14 +144,13 @@ export const DescriptiveCard: React.FC<Props> = ({
                         {imageURL && (
                             <tr>
                                 <td style={{ padding: 0 }}>
-                                    <a href={webURL}>
-                                        <img
-                                            width="600"
-                                            style={imgStyle}
-                                            alt={imageAlt}
-                                            src={imageURL}
-                                        />
-                                    </a>
+                                    <Image
+                                        width={600}
+                                        alt={imageAlt}
+                                        src={imageURL}
+                                        linkTo={webURL}
+                                        pillar={pillar}
+                                    />
                                 </td>
                             </tr>
                         )}

--- a/src/components/cards/MediaCardB.tsx
+++ b/src/components/cards/MediaCardB.tsx
@@ -1,10 +1,11 @@
 import React from "react";
-import { TdCSS, ImageCSS } from "../../css";
+import { TdCSS } from "../../css";
 import { palette } from "@guardian/src-foundations";
 import { Content } from "../../api";
 import { formatImage } from "../../image";
 import { Table, RowCell, TableRowCell } from "../../layout/Table";
 import { Padding } from "../../layout/Padding";
+import { Image } from "../../components/Image";
 
 const tdStyle: TdCSS = {
     backgroundColor: palette.neutral[20],
@@ -19,41 +20,12 @@ const tdHeadlineStyle: TdCSS = {
     fontWeight: 400
 };
 
-const imgStyle: ImageCSS = {
-    outline: "none",
-    textDecoration: "none",
-    maxWidth: "100%",
-    clear: "both",
-    display: "block",
-    border: "0",
-    width: "100%",
-    fontFamily: "Georgia, serif",
-    color: palette.opinion.main
-};
-
 interface Props {
     content: Content;
     salt: string;
 }
 
 const brazeParameter = "?##braze_utm##";
-
-const Image: React.FC<{
-    src?: string;
-    linkURL: string;
-    alt: string;
-    width: number;
-}> = ({ src, linkURL, alt, width }) => {
-    if (!src) {
-        return null;
-    }
-
-    return (
-        <a href={linkURL}>
-            <img width={width} style={imgStyle} alt={alt} src={src} />
-        </a>
-    );
-};
 
 export const MediaCardB: React.FC<Props> = ({ content, salt }) => {
     const image =
@@ -80,9 +52,10 @@ export const MediaCardB: React.FC<Props> = ({ content, salt }) => {
                 <RowCell tdStyle={{ padding: "0" }}>
                     <Image
                         src={imageURL}
-                        linkURL={webURL}
+                        linkTo={webURL}
                         alt={imageAlt}
-                        width={579}
+                        width={580}
+                        pillar="Opinion"
                     />
                 </RowCell>
             </Table>

--- a/src/components/cards/MediaCardC.tsx
+++ b/src/components/cards/MediaCardC.tsx
@@ -1,9 +1,10 @@
 import React from "react";
-import { TdCSS, ImageCSS } from "../../css";
+import { TdCSS } from "../../css";
 import { palette } from "@guardian/src-foundations";
 import { Content } from "../../api";
 import { formatImage } from "../../image";
 import { Table, RowCell, TableRowCell } from "../../layout/Table";
+import { Image } from "../../components/Image";
 
 const tdStyle: TdCSS = {
     backgroundColor: palette.neutral[100],
@@ -20,41 +21,12 @@ const tdHeadlineStyle: TdCSS = {
     fontWeight: 400
 };
 
-const imgStyle: ImageCSS = {
-    outline: "none",
-    textDecoration: "none",
-    maxWidth: "100%",
-    clear: "both",
-    display: "block",
-    border: "0",
-    width: "100%",
-    fontFamily: "Georgia, serif",
-    color: palette.opinion.main
-};
-
 interface Props {
     content: Content;
     salt: string;
 }
 
 const brazeParameter = "?##braze_utm##";
-
-const Image: React.FC<{
-    src?: string;
-    linkURL: string;
-    alt: string;
-    width: number;
-}> = ({ src, linkURL, alt, width }) => {
-    if (!src) {
-        return null;
-    }
-
-    return (
-        <a href={linkURL}>
-            <img width={width} style={imgStyle} alt={alt} src={src} />
-        </a>
-    );
-};
 
 export const MediaCardC: React.FC<Props> = ({ content, salt }) => {
     const image =
@@ -77,9 +49,10 @@ export const MediaCardC: React.FC<Props> = ({ content, salt }) => {
                 <RowCell tdStyle={{ padding: "0" }}>
                     <Image
                         src={imageURL}
-                        linkURL={webURL}
+                        linkTo={webURL}
                         alt={imageAlt}
                         width={579}
+                        pillar="Opinion"
                     />
                 </RowCell>
                 <RowCell tdStyle={tdHeadlineStyle}>{headline}</RowCell>

--- a/src/components/cards/OverlayCard.tsx
+++ b/src/components/cards/OverlayCard.tsx
@@ -7,6 +7,7 @@ import { Content } from "../../api";
 import { formatImage } from "../../image";
 import { kickerText } from "../../kicker";
 import { Headline } from "../../components/Headline";
+import { Image } from "../../components/Image";
 
 const fontSizes = {
     large: {
@@ -20,14 +21,14 @@ const fontSizes = {
 };
 
 const imgStyle: ImageCSS = {
-    outline: "none",
-    textDecoration: "none",
-    maxWidth: "100%",
-    clear: "both",
-    display: "block",
-    border: "0",
-    width: "100%",
-    fontFamily: "Georgia, serif",
+    // outline: "none",
+    // textDecoration: "none",
+    // maxWidth: "100%",
+    // clear: "both",
+    // display: "block",
+    // border: "0",
+    // width: "100%",
+    // fontFamily: "Georgia, serif",
     color: palette.culture.main
 };
 
@@ -113,14 +114,20 @@ export const OverlayCard: React.FC<Props> = ({
                                     colspan={layout === "compact" ? null : 2}
                                     style={{ padding: 0 }}
                                 >
-                                    <a href={webURL}>
+                                    <Image
+                                        src={imageURL}
+                                        alt={imageAlt}
+                                        width={600}
+                                        extraStyles={imgStyle}
+                                    />
+                                    {/* <a href={webURL}>
                                         <img
                                             width={600}
                                             style={imgStyle}
                                             alt={imageAlt}
                                             src={imageURL}
                                         />
-                                    </a>
+                                    </a> */}
                                 </td>
                             </tr>
                         )}

--- a/src/components/cards/OverlayCard.tsx
+++ b/src/components/cards/OverlayCard.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import sanitizeHtml from "sanitize-html";
 import { palette } from "@guardian/src-foundations";
-import { FontCSS, TdCSS, TableCSS, ImageCSS } from "../../css";
+import { FontCSS, TdCSS, TableCSS } from "../../css";
 import { sanitizeOptions } from "../../utils/sanitizeOptions";
 import { Content } from "../../api";
 import { formatImage } from "../../image";
@@ -18,18 +18,6 @@ const fontSizes = {
         fontSize: "16px",
         lineHeight: "20px"
     }
-};
-
-const imgStyle: ImageCSS = {
-    // outline: "none",
-    // textDecoration: "none",
-    // maxWidth: "100%",
-    // clear: "both",
-    // display: "block",
-    // border: "0",
-    // width: "100%",
-    // fontFamily: "Georgia, serif",
-    color: palette.culture.main
 };
 
 const tableStyle: TableCSS = {
@@ -97,6 +85,10 @@ export const OverlayCard: React.FC<Props> = ({
     const imageAlt = content.header.headline;
     const showQuotation = content.display.showQuotedHeadline;
 
+    const pillar = content.properties.maybeContent
+        ? content.properties.maybeContent.metadata.pillar.name
+        : null;
+
     const kicker = content.header.kicker
         ? kickerText(content.header.kicker)
         : "";
@@ -118,16 +110,9 @@ export const OverlayCard: React.FC<Props> = ({
                                         src={imageURL}
                                         alt={imageAlt}
                                         width={600}
-                                        extraStyles={imgStyle}
+                                        pillar={pillar}
+                                        linkTo={webURL}
                                     />
-                                    {/* <a href={webURL}>
-                                        <img
-                                            width={600}
-                                            style={imgStyle}
-                                            alt={imageAlt}
-                                            src={imageURL}
-                                        />
-                                    </a> */}
                                 </td>
                             </tr>
                         )}


### PR DESCRIPTION
## What does this change?
Adds a reusable Image component to be used for all content images. Also replaces all local HTML image tags with an instance of this new component, and cleans lots of old image CSS.

## Why?
So that we can easily reuse image styles across the cards.

## Link to supporting Trello card
https://trello.com/c/RnfHDPUN/85-create-image-component