### PR TITLE
Reverts Film Today variant B to original design

### DIFF
--- a/src/components/cards/DefaultCard.tsx
+++ b/src/components/cards/DefaultCard.tsx
@@ -51,7 +51,6 @@ export const DefaultCard: React.FC<Props> = ({ content, salt, size }) => {
     );
 
     const headline = content.header.headline;
-    const byline = content.properties.byline;
     const webURL = content.properties.webUrl + brazeParameter;
     const imageURL = formattedImage;
     const imageAlt = content.header.headline;
@@ -60,6 +59,12 @@ export const DefaultCard: React.FC<Props> = ({ content, salt, size }) => {
     const pillar = content.properties.maybeContent
         ? content.properties.maybeContent.metadata.pillar.name
         : null;
+
+    const { showByline } = content.properties;
+    const byline =
+        showByline && content.properties.byline
+            ? content.properties.byline
+            : "";
 
     const kicker = content.header.kicker
         ? kickerText(content.header.kicker)

--- a/src/fronts/film-today/variantB/Collections.tsx
+++ b/src/fronts/film-today/variantB/Collections.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Collection as ICollection } from "../../../api";
 import { TableRowCell } from "../../../layout/Table";
 import { getDesignType } from "../../../utils/getDesignType";
-import { InstagramCollection } from "../../../collections/InstagramCollection";
+import { DefaultCollection } from "./components/DefaultCollection";
 
 export const Collections: React.FC<{
     frontId: string;
@@ -16,7 +16,7 @@ export const Collections: React.FC<{
         switch (designType) {
             case "default":
                 return (
-                    <InstagramCollection collection={collection} salt={salt} />
+                    <DefaultCollection collection={collection} salt={salt} />
                 );
         }
     });

--- a/src/fronts/film-today/variantB/components/DefaultCollection.tsx
+++ b/src/fronts/film-today/variantB/components/DefaultCollection.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { Collection as ICollection } from "../../../../api";
+import { DefaultGrid } from "../../../../layout/Grid";
+import { Padding } from "../../../../layout/Padding";
+import { Multiline } from "../../../../components/Multiline";
+import { Heading } from "../../../../components/Heading";
+import { DefaultCard } from "../../../../components/cards/DefaultCard";
+import { palette } from "@guardian/src-foundations";
+import { TableRowCell } from "../../../../layout/Table";
+
+export const DefaultCollection: React.FC<{
+    collection: ICollection;
+    salt?: string;
+}> = ({ collection, salt }) => {
+    const topCollection = collection.backfill.slice(0, 2);
+    const gridContent = collection.backfill.slice(2, 6);
+    const lightGrey = palette.neutral[97];
+
+    return (
+        <>
+            <TableRowCell
+                tdStyle={{ backgroundColor: lightGrey, padding: "0" }}
+            >
+                <Multiline topPadding />
+                <Heading heading={collection.displayName} />
+            </TableRowCell>
+            {topCollection.map(content => {
+                return (
+                    <>
+                        <DefaultCard
+                            content={content}
+                            salt={salt}
+                            size="large"
+                        />
+                        <Padding px={12} />
+                    </>
+                );
+            })}
+            {gridContent && <DefaultGrid content={gridContent} salt={salt} />}
+        </>
+    );
+};

--- a/src/fronts/film-today/variantC/components/DefaultCollection.tsx
+++ b/src/fronts/film-today/variantC/components/DefaultCollection.tsx
@@ -6,6 +6,7 @@ import { Multiline } from "../../../../components/Multiline";
 import { Heading } from "../../../../components/Heading";
 import { HeadlineCard } from "../../../../components/cards/HeadlineCard";
 import { DescriptiveCard } from "../../../../components/cards/DescriptiveCard";
+import { Padding } from "../../../../layout/Padding";
 
 export const DefaultCollection: React.FC<{
     collection: ICollection;
@@ -21,6 +22,7 @@ export const DefaultCollection: React.FC<{
             <Multiline />
             <Heading heading="More top stories" />
             {gridContent && <DefaultGrid content={gridContent} salt={salt} />}
+            <Padding px={12} />
             <HeadlineCard
                 content={lastContent}
                 backgroundColor={palette.culture.faded}

--- a/src/fronts/media-briefing/variantD/Collections.tsx
+++ b/src/fronts/media-briefing/variantD/Collections.tsx
@@ -6,6 +6,7 @@ import { TopCollection } from "./components/TopCollection";
 import { CommentCollection } from "./components/CommentCollection";
 import { LinkCollection } from "./components/LinkCollection";
 import { GenericCollection } from "../../../collections/GenericCollection";
+import { Padding } from "../../../layout/Padding";
 
 export const Collections: React.FC<{
     frontId: string;
@@ -41,10 +42,13 @@ export const Collections: React.FC<{
                     collection.href.indexOf("tv-and-radio") > -1
                 ) {
                     return (
-                        <GenericCollection
-                            collection={collection}
-                            salt={salt}
-                        />
+                        <>
+                            <GenericCollection
+                                collection={collection}
+                                salt={salt}
+                            />
+                            <Padding px={12} />
+                        </>
                     );
                 }
 

--- a/src/fronts/opinion/variantB/components/Grid.tsx
+++ b/src/fronts/opinion/variantB/components/Grid.tsx
@@ -96,8 +96,9 @@ interface LinkGridProps {
 // TODO really should accept a React element so that it doesn't have to know
 // about Card or salt.
 export const LinkGrid: React.FC<LinkGridProps> = ({ content, salt }) => {
-    const rows = partition(content, 2).map((pair, i) => (
-        <React.Fragment key={i}>
+    const rowsArray = partition(content, 2);
+    const rows = rowsArray.map((pair, index) => (
+        <React.Fragment key={index}>
             <GridRow
                 left={<LinkCardB content={pair[0]} theme="dark" />}
                 right={
@@ -112,8 +113,7 @@ export const LinkGrid: React.FC<LinkGridProps> = ({ content, salt }) => {
                     backgroundColor: palette.neutral[86]
                 }}
             />
-
-            <Padding px={12} />
+            {index < rowsArray.length - 1 && <Padding px={12} />}
         </React.Fragment>
     ));
 

--- a/src/fronts/opinion/variantC/components/Grid.tsx
+++ b/src/fronts/opinion/variantC/components/Grid.tsx
@@ -131,8 +131,9 @@ interface LinkGridProps {
 // TODO really should accept a React element so that it doesn't have to know
 // about Card or salt.
 export const LinkGrid: React.FC<LinkGridProps> = ({ content, salt }) => {
-    const rows = partition(content, 2).map((pair, i) => (
-        <React.Fragment key={i}>
+    const rowsArray = partition(content, 2);
+    const rows = rowsArray.map((pair, index) => (
+        <React.Fragment key={index}>
             <GridRow
                 left={<LinkCardC content={pair[0]} />}
                 right={pair[1] ? <LinkCardC content={pair[1]} /> : null}
@@ -147,8 +148,7 @@ export const LinkGrid: React.FC<LinkGridProps> = ({ content, salt }) => {
                     borderBottom: `1px solid ${palette.neutral[20]}`
                 }}
             />
-
-            <Padding px={12} />
+            {index < rowsArray.length - 1 && <Padding px={12} />}
         </React.Fragment>
     ));
 

--- a/src/layout/Grid.tsx
+++ b/src/layout/Grid.tsx
@@ -72,8 +72,9 @@ interface DefaultGridProps {
 // TODO really should accept a React element so that it doesn't have to know
 // about Card or salt.
 export const DefaultGrid: React.FC<DefaultGridProps> = ({ content, salt }) => {
-    const rows = partition(content, 2).map((pair, i) => (
-        <React.Fragment key={i}>
+    const rowsArray = partition(content, 2);
+    const rows = rowsArray.map((pair, index) => (
+        <React.Fragment key={index}>
             <GridRow
                 left={
                     <DefaultCard content={pair[0]} salt={salt} size={"small"} />
@@ -94,8 +95,7 @@ export const DefaultGrid: React.FC<DefaultGridProps> = ({ content, salt }) => {
                     backgroundColor: palette.culture.faded
                 }}
             />
-
-            <Padding px={12} />
+            {index < rowsArray.length - 1 && <Padding px={12} />}
         </React.Fragment>
     ));
 


### PR DESCRIPTION
## What does this change?
Reverts Film Today variant B to use the previous design based on two lead stories plus a grid of 2 x 2.

## Why?
Because this designs works better than the one we were trying out.

## Link to supporting Trello card
https://trello.com/c/K8F08mFg/87-revert-previous-design-on-film-today-variant-b