### PR TITLE
Image accepts prop to bypass default width

### DIFF
--- a/src/components/Image.tsx
+++ b/src/components/Image.tsx
@@ -23,17 +23,25 @@ interface Props {
     extraStyles?: ImageCSS;
     linkTo?: string;
     pillar?: Pillar;
+    ignoreWidth?: boolean;
 }
 
-const defaultImageStyles: ImageCSS = {
-    fontFamily: "Georgia, serif",
-    textDecoration: "none",
-    width: "100%",
-    maxWidth: "100%",
-    outline: "none",
-    display: "block",
-    clear: "both",
-    border: "0"
+const defaultImageStyles = (ignoreWidth: boolean): ImageCSS => {
+    const sizingStyles: ImageCSS = {};
+    if (!ignoreWidth) {
+        sizingStyles.width = "100%";
+    }
+
+    return {
+        fontFamily: "Georgia, serif",
+        textDecoration: "none",
+        maxWidth: "100%",
+        outline: "none",
+        display: "block",
+        clear: "both",
+        border: "0",
+        ...sizingStyles
+    };
 };
 
 export const Image: React.FC<Props> = ({
@@ -43,7 +51,8 @@ export const Image: React.FC<Props> = ({
     height,
     extraStyles,
     linkTo,
-    pillar
+    pillar,
+    ignoreWidth
 }) => {
     // If a pillar has been passed in, add its colour to the image styles
     // Defaults to dark grey when no pillar available
@@ -55,7 +64,7 @@ export const Image: React.FC<Props> = ({
 
     // Combine all image styles allowing styles passed in via props to take precedence over default styles
     const imageStyles = {
-        ...defaultImageStyles,
+        ...defaultImageStyles(ignoreWidth),
         ...imagePillarStyles,
         ...extraStyles
     };

--- a/src/components/cards/CommentCardB.tsx
+++ b/src/components/cards/CommentCardB.tsx
@@ -83,7 +83,13 @@ const ContributorImage: React.FC<{
 
     const formattedImage = formatImage(src, salt, width);
     return (
-        <Image src={formattedImage} width={width} alt={alt} pillar="Opinion" />
+        <Image
+            src={formattedImage}
+            width={width}
+            alt={alt}
+            pillar="Opinion"
+            ignoreWidth
+        />
     );
 };
 

--- a/src/components/cards/CommentCardC.tsx
+++ b/src/components/cards/CommentCardC.tsx
@@ -87,7 +87,13 @@ const ContributorImage: React.FC<{
 
     const formattedImage = formatImage(src, salt, width);
     return (
-        <Image src={formattedImage} width={width} alt={alt} pillar="Opinion" />
+        <Image
+            src={formattedImage}
+            width={width}
+            alt={alt}
+            pillar="Opinion"
+            ignoreWidth
+        />
     );
 };
 


### PR DESCRIPTION
## What does this change?
Extends the Image component so that a prop can be passed in telling it to not add the default 'width' property. Currently only useful in Opinion (contributor images).

## Why?
Because a default `width: 100%` on Contributor images was causing issues on some email clients.