### PR TITLE
Add Route53 healthcheck

### DIFF
--- a/src/cdk/app.ts
+++ b/src/cdk/app.ts
@@ -2,6 +2,8 @@ import cdk = require("@aws-cdk/core");
 import apigateway = require("@aws-cdk/aws-apigateway");
 import lambda = require("@aws-cdk/aws-lambda");
 import iam = require("@aws-cdk/aws-iam");
+import route53 = require("@aws-cdk/aws-route53");
+import cloudwatch = require("@aws-cdk/aws-cloudwatch");
 
 export class EmailService extends cdk.Stack {
     constructor(scope: cdk.Construct, id: string) {
@@ -45,6 +47,17 @@ export class EmailService extends cdk.Stack {
             description: "Serves editorial email fronts.",
             proxy: true,
             handler
+        });
+
+        // tslint:disable-next-line: no-unused-expression
+        new route53.CfnHealthCheck(this, "editorial-emails-healthcheck", {
+            healthCheckConfig: {
+                type: "HTTPS:",
+                fullyQualifiedDomainName: "email-newsletters.theguardian.com",
+                resourcePath: "/healthcheck",
+                port: 443,
+                failureThreshold: 3
+            }
         });
     }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,6 +16,8 @@ const imageSalt: Promise<string> = process.env.IMAGE_SALT
     ? Promise.resolve(process.env.IMAGE_SALT)
     : getParam("/frontend/images.signature-salt");
 
+app.get("/healthcheck", (req, res) => res.send({ status: "okay" }));
+
 // HTML version as JSON - for Braze/clients
 app.get(
     "/:path.json",


### PR DESCRIPTION
## What does this change?

Adds a basic healthcheck.

Note, once I'm confident this is working okay, I'll create a separate PR to add the actual alarm on this.

## Why?

To let us know if the service goes down for some reason.

## Link to supporting Trello card

https://trello.com/c/taC5yjWL/79-production-ready-tasks