### PR TITLE
Conditionally apply background/border to DefaultCard or Grid cell

### DIFF
--- a/src/components/cards/DefaultCard.tsx
+++ b/src/components/cards/DefaultCard.tsx
@@ -14,7 +14,8 @@ type DesignName = "background" | "border";
 const tableStyle: TableCSS = {
     borderSpacing: 0,
     borderCollapse: "collapse",
-    width: "100%"
+    width: "100%",
+    height: "100%"
 };
 
 const tdStyle = (designName: DesignName, isInsideGrid: boolean): TdCSS => {

--- a/src/components/cards/DefaultCard.tsx
+++ b/src/components/cards/DefaultCard.tsx
@@ -45,6 +45,7 @@ const tdStyle = (designName: DesignName, isInsideGrid: boolean): TdCSS => {
 const metaWrapperStyle = (size: Size): TdCSS => {
     const rightPad = size === "large" ? "40px" : "10px";
     return {
+        height: "100%",
         padding: `3px ${rightPad} 5px 10px`
     };
 };

--- a/src/components/cards/DefaultCard.tsx
+++ b/src/components/cards/DefaultCard.tsx
@@ -14,15 +14,21 @@ type DesignName = "background" | "border";
 const tableStyle: TableCSS = {
     borderSpacing: 0,
     borderCollapse: "collapse",
-    width: "100%",
-    height: "100%"
+    width: "100%"
 };
 
-const tdStyle = (designName: DesignName): TdCSS => {
+const tdStyle = (designName: DesignName, isInsideGrid: boolean): TdCSS => {
     if (designName === "border") {
+        if (!isInsideGrid) {
+            return {
+                border: `1px solid ${palette.neutral[93]}`,
+                backgroundColor: palette.neutral[100],
+                padding: "0",
+                verticalAlign: "top"
+            };
+        }
+
         return {
-            border: `1px solid ${palette.neutral[93]}`,
-            backgroundColor: palette.neutral[100],
             padding: "0",
             verticalAlign: "top"
         };
@@ -38,7 +44,6 @@ const tdStyle = (designName: DesignName): TdCSS => {
 const metaWrapperStyle = (size: Size): TdCSS => {
     const rightPad = size === "large" ? "40px" : "10px";
     return {
-        height: "100%",
         padding: `3px ${rightPad} 5px 10px`
     };
 };
@@ -52,6 +57,7 @@ interface Props {
     salt: string;
     size: Size;
     designName?: DesignName;
+    isInsideGrid?: boolean;
 }
 
 const brazeParameter = "?##braze_utm##";
@@ -60,7 +66,8 @@ export const DefaultCard: React.FC<Props> = ({
     content,
     salt,
     size,
-    designName = "background"
+    designName = "background",
+    isInsideGrid = false
 }) => {
     const image =
         content.properties.maybeContent.trail.trailPicture.allImages[0];
@@ -94,7 +101,7 @@ export const DefaultCard: React.FC<Props> = ({
     return (
         <table style={tableStyle}>
             <tr>
-                <td style={tdStyle(designName)}>
+                <td style={tdStyle(designName, isInsideGrid)}>
                     <table style={tableStyle}>
                         {imageURL && (
                             <tr>

--- a/src/fronts/opinion/variantB/Collections.tsx
+++ b/src/fronts/opinion/variantB/Collections.tsx
@@ -6,7 +6,6 @@ import { EditorialCollection } from "./components/EditorialCollection";
 import { MediaCollection } from "./components/MediaCollection";
 import { LinkCollection } from "./components/LinkCollection";
 import { DefaultCollection } from "./components/DefaultCollection";
-
 import { getDesignType } from "../../../utils/getDesignType";
 
 export const Collections: React.FC<{

--- a/src/fronts/opinion/variantC/Collections.tsx
+++ b/src/fronts/opinion/variantC/Collections.tsx
@@ -6,7 +6,6 @@ import { EditorialCollection } from "./components/EditorialCollection";
 import { MediaCollection } from "./components/MediaCollection";
 import { LinkCollection } from "./components/LinkCollection";
 import { DefaultCollection } from "./components/DefaultCollection";
-
 import { getDesignType } from "../../../utils/getDesignType";
 
 export const Collections: React.FC<{

--- a/src/fronts/sport-au/variantC/components/DefaultCollection.tsx
+++ b/src/fronts/sport-au/variantC/components/DefaultCollection.tsx
@@ -4,12 +4,23 @@ import { DefaultGrid } from "../../../../layout/Grid";
 import { Multiline } from "../../../../components/Multiline";
 import { Heading } from "../../../../components/Heading";
 import { DefaultCard } from "../../../../components/cards/DefaultCard";
+import { palette } from "@guardian/src-foundations";
 
 export const DefaultCollection: React.FC<{
     collection: ICollection;
     salt?: string;
 }> = ({ collection, salt }) => {
     const content = collection.backfill;
+
+    // Pass a background color and border styles to be used by the grid cell.
+    // This ensures all cells in a row will have the same background and border,
+    // giving the impression that the cards inside match each other's heights.
+    // This is needed because we can't rely on the cards themselves
+    // expanding vertically in the cell to use the available height.
+    const colStyles = {
+        backgroundColor: palette.neutral[100],
+        border: `1px solid ${palette.neutral[93]}`
+    };
 
     return (
         <>
@@ -21,8 +32,10 @@ export const DefaultCollection: React.FC<{
                 salt={salt}
                 card={{
                     Component: DefaultCard,
-                    props: { designName: "border" }
+                    props: { designName: "border", isInsideGrid: true }
                 }}
+                leftStyles={colStyles}
+                rightStyles={colStyles}
             />
         </>
     );

--- a/src/fronts/sport-au/variantC/components/TopCollection.tsx
+++ b/src/fronts/sport-au/variantC/components/TopCollection.tsx
@@ -6,6 +6,7 @@ import { Multiline } from "../../../../components/Multiline";
 import { Heading } from "../../../../components/Heading";
 import { DefaultGrid } from "../../../../layout/Grid";
 import { DefaultCard } from "../../../../components/cards/DefaultCard";
+import { palette } from "@guardian/src-foundations";
 
 export const TopCollection: React.FC<{
     collection: ICollection;
@@ -15,6 +16,17 @@ export const TopCollection: React.FC<{
     const secondCollection = collection.backfill.slice(1, 3);
     const thirdCollection = collection.backfill[3];
     const fourthCollection = collection.backfill.slice(4, 6);
+
+    // Pass a background color and border styles to be used by the grid cell.
+    // This ensures all cells in a row will have the same background and border,
+    // giving the impression that the cards inside match each other's heights.
+    // This is needed because we can't rely on the cards themselves
+    // expanding vertically in the cell to use the available height.
+    const colStyles = {
+        backgroundColor: palette.neutral[100],
+        border: `1px solid ${palette.neutral[93]}`
+    };
+
     return (
         <>
             <Multiline topPadding />
@@ -32,8 +44,10 @@ export const TopCollection: React.FC<{
                     salt={salt}
                     card={{
                         Component: DefaultCard,
-                        props: { designName: "border" }
+                        props: { designName: "border", isInsideGrid: true }
                     }}
+                    leftStyles={colStyles}
+                    rightStyles={colStyles}
                 />
             )}
             <Padding px={12} />
@@ -50,8 +64,10 @@ export const TopCollection: React.FC<{
                     salt={salt}
                     card={{
                         Component: DefaultCard,
-                        props: { designName: "border" }
+                        props: { designName: "border", isInsideGrid: true }
                     }}
+                    leftStyles={colStyles}
+                    rightStyles={colStyles}
                 />
             )}
         </>

--- a/src/layout/Grid.tsx
+++ b/src/layout/Grid.tsx
@@ -29,8 +29,8 @@ const colStyle = (styles: RowStyle): TdCSS => {
     if (styles.border) {
         borderStyles.border = styles.border;
     } else {
-        borderStyles.borderBottom = styles.borderBottom;
-        borderStyles.borderLeft = styles.borderLeft;
+        borderStyles.borderBottom = styles.borderBottom || "none";
+        borderStyles.borderLeft = styles.borderLeft || "none";
     }
 
     return {

--- a/src/layout/Grid.tsx
+++ b/src/layout/Grid.tsx
@@ -16,23 +16,41 @@ type VAlign = "top" | "bottom";
 interface RowStyle {
     backgroundColor: string;
     verticalAlign?: VAlign;
+    border?: string;
     borderBottom?: string;
     borderLeft?: string;
     lineHeight?: string;
 }
 
-const colStyle = (styles: RowStyle): TdCSS => ({
-    width: "49%",
-    backgroundColor: styles.backgroundColor || "transparent",
-    verticalAlign: styles.verticalAlign || "top",
-    borderBottom: styles.borderBottom || "none",
-    borderLeft: styles.borderLeft || "none",
-    lineHeight: styles.lineHeight || "inherit",
-    padding: "0"
-});
+const colStyle = (styles: RowStyle): TdCSS => {
+    // Ensure we only apply the border shorthand property
+    // OR the individual border declarations.
+    const borderStyles: TdCSS = {};
+    if (styles.border) {
+        borderStyles.border = styles.border;
+    } else {
+        borderStyles.borderBottom = styles.borderBottom;
+        borderStyles.borderLeft = styles.borderLeft;
+    }
 
+    return {
+        width: "49%",
+        backgroundColor: styles.backgroundColor || "transparent",
+        verticalAlign: styles.verticalAlign || "top",
+        lineHeight: styles.lineHeight || "inherit",
+        padding: "0",
+        height: "100%",
+        ...borderStyles
+    };
+};
+
+// By default, give the grid cells this background colour,
+// which works well with the Default Card component used by the grid.
+// This background colour can be overriden via props,
+// which is useful behaviour if we choose to use the Grid
+// with a different card component.
 const defaultRowStyles: RowStyle = {
-    backgroundColor: palette.neutral[100]
+    backgroundColor: palette.culture.faded
 };
 
 export const GridRow: React.FC<{
@@ -80,6 +98,8 @@ interface DefaultGridProps {
     content: Content[];
     salt: string;
     card?: GridCard;
+    leftStyles?: RowStyle;
+    rightStyles?: RowStyle;
 }
 
 const defaultCard = {
@@ -92,7 +112,9 @@ const defaultCard = {
 export const DefaultGrid: React.FC<DefaultGridProps> = ({
     content,
     salt,
-    card = defaultCard
+    card = defaultCard,
+    leftStyles,
+    rightStyles
 }) => {
     const rowsArray = partition(content, 2);
     const { Component, props } = card;
@@ -117,6 +139,8 @@ export const DefaultGrid: React.FC<DefaultGridProps> = ({
                         />
                     ) : null
                 }
+                leftStyles={leftStyles}
+                rightStyles={rightStyles}
             />
             {index < rowsArray.length - 1 && <Padding px={12} />}
         </React.Fragment>


### PR DESCRIPTION
## What does this change?
Extends the DefaultCard so it knows whether or not it's being used inside a Grid, and therefore conditionally apply border and/or background which may otherwise be responsibility of the grid cell. Also expands the Grid component so it can take those same two styles and use them properly if they're responsibility of the Grid and not the Card. 😒

NOTE: the previous implementation worked fine on 99.99% of the cases; only a tiny minority of email clients had an issue with it; but we decided to fix the issue anyway so that we're confident we have the same behaviour across clients.

## Why?
Because we can't rely on Cards expanding vertically to take the height available in the cell, due to email client inconsistencies. Therefore, we need to programatically define whether the Card or the Grid cell should apply the background and borders, so that all columns in the same row appear properly aligned. 🤷‍♂️

## Link to supporting Trello card
https://trello.com/c/aZ7ZFCOU/93-add-fix-for-misaligned-cards-when-used-inside-grid