### PR TITLE
Add disclaimer to text version

### DIFF
--- a/src/Email.tsx
+++ b/src/Email.tsx
@@ -33,7 +33,7 @@ const getTitleFromFrontId = (id: string): string => {
         .join(" ");
 };
 
-const getPageTitle = (front: Front): string => {
+export const getPageTitle = (front: Front): string => {
     if (front.seoData && front.seoData.webTitle) {
         return front.seoData.webTitle;
     }

--- a/src/Text.tsx
+++ b/src/Text.tsx
@@ -1,7 +1,10 @@
 import { Front } from "./api";
+import { getPageTitle } from "./Email";
+import { disclaimer } from "./components/Footer";
 
 // The text-only email version
 export const Text = (front: Front): string => {
+    const pageTitle = getPageTitle(front);
     const collection = front.collections[0];
 
     return `${front.seoData.webTitle} | The Guardian
@@ -13,7 +16,10 @@ ${collection.displayName}
 ${collection.backfill
     .map(
         content =>
-            `${content.properties.webTitle}\n${content.properties.webUrl}\n\n\n`
+            `${content.properties.webTitle}\n${content.properties.webUrl}`
     )
-    .join("")}`;
+    .join("\n\n\n")}
+
+
+${disclaimer(pageTitle)}`;
 };

--- a/src/Text.tsx
+++ b/src/Text.tsx
@@ -16,9 +16,12 @@ ${collection.displayName}
 ${collection.backfill
     .map(
         content =>
-            `${content.properties.webTitle}\n${content.properties.webUrl}`
+            `${content.header.headline}\n${content.properties.webUrl}##braze_utm##`
     )
     .join("\n\n\n")}
+
+
+Read online: https://www.theguardian.com/${front.id}?##braze_utm##.
 
 
 ${disclaimer(pageTitle)}`;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -44,6 +44,11 @@ const linkStyle: LinkCSS = {
     textDecoration: "none"
 };
 
+export const disclaimer = (
+    title: string
+): string => `You are receiving this email because you are a subscriber to ${title}. Guardian News & Media Limited - a member of Guardian Media Group PLC. Registered Office: Kings Place, 90 York Way, London, N1 9GU.
+Registered in England No. 908396.`;
+
 export const Footer: React.FC<{ title: string; frontId: string }> = ({
     title,
     frontId
@@ -88,13 +93,7 @@ export const Footer: React.FC<{ title: string; frontId: string }> = ({
                                     </tr>
                                     <tr>
                                         <td style={tdDisclaimer}>
-                                            You are receiving this email because
-                                            you are a subscriber to {title}.
-                                            Guardian News &amp; Media Limited -
-                                            a member of Guardian Media Group
-                                            PLC. Registered Office: Kings Place,
-                                            90 York Way, London, N1 9GU.
-                                            Registered in England No. 908396.
+                                            {disclaimer(title)}
                                         </td>
                                     </tr>
                                 </table>


### PR DESCRIPTION
## What does this change?

Adds disclaimer/address to text-only version.

![Screenshot 2019-12-10 at 17 48 28](https://user-images.githubusercontent.com/858402/70554583-4c183580-1b75-11ea-9523-9ff792d0393f.png)

## Why?

For parity.

## Link to supporting Trello card

https://trello.com/c/yK4zgCuI/99-add-disclaimer-to-text-only-version