### PR TITLE
Bugfix - adds checks around getContributor

### DIFF
--- a/src/components/cards/CommentCardB.tsx
+++ b/src/components/cards/CommentCardB.tsx
@@ -156,6 +156,9 @@ export const CommentCardB: React.FC<Props> = ({
     size,
     shouldShowImage
 }) => {
+    // console.log("=== COMMENT CARD: ");
+    // console.log(content.properties.webTitle);
+
     const image =
         content.properties.maybeContent.trail.trailPicture.allImages[0];
     const formattedImage = formatImage(
@@ -175,6 +178,8 @@ export const CommentCardB: React.FC<Props> = ({
     const contributor = content.properties.maybeContent.tags.tags.find(tag => {
         return tag.properties.tagType === "Contributor";
     });
+
+    // console.log("Contributor: ", contributor);
 
     const profilePic = contributor
         ? contributor.properties.contributorLargeImagePath
@@ -240,14 +245,19 @@ export const ContributorImageWrapper: React.FC<{
     salt: string;
 }> = ({ content, salt }) => {
     const contributor = getContributor(content);
-    const profilePic = contributor.properties.contributorLargeImagePath || null;
+    if (contributor) {
+        const profilePic =
+            contributor.properties.contributorLargeImagePath || null;
 
-    return (
-        <ContributorImage
-            salt={salt}
-            width={147}
-            src={profilePic}
-            alt={contributor.properties.webTitle}
-        />
-    );
+        return (
+            <ContributorImage
+                salt={salt}
+                width={147}
+                src={profilePic}
+                alt={contributor.properties.webTitle}
+            />
+        );
+    }
+
+    return null;
 };

--- a/src/components/cards/CommentCardB.tsx
+++ b/src/components/cards/CommentCardB.tsx
@@ -240,19 +240,17 @@ export const ContributorImageWrapper: React.FC<{
     salt: string;
 }> = ({ content, salt }) => {
     const contributor = getContributor(content);
-    if (contributor) {
-        const profilePic =
-            contributor.properties.contributorLargeImagePath || null;
-
-        return (
-            <ContributorImage
-                salt={salt}
-                width={147}
-                src={profilePic}
-                alt={contributor.properties.webTitle}
-            />
-        );
+    if (!contributor) {
+        return null;
     }
 
-    return null;
+    const profilePic = contributor.properties.contributorLargeImagePath || null;
+    return (
+        <ContributorImage
+            salt={salt}
+            width={147}
+            src={profilePic}
+            alt={contributor.properties.webTitle}
+        />
+    );
 };

--- a/src/components/cards/CommentCardB.tsx
+++ b/src/components/cards/CommentCardB.tsx
@@ -156,9 +156,6 @@ export const CommentCardB: React.FC<Props> = ({
     size,
     shouldShowImage
 }) => {
-    // console.log("=== COMMENT CARD: ");
-    // console.log(content.properties.webTitle);
-
     const image =
         content.properties.maybeContent.trail.trailPicture.allImages[0];
     const formattedImage = formatImage(
@@ -178,8 +175,6 @@ export const CommentCardB: React.FC<Props> = ({
     const contributor = content.properties.maybeContent.tags.tags.find(tag => {
         return tag.properties.tagType === "Contributor";
     });
-
-    // console.log("Contributor: ", contributor);
 
     const profilePic = contributor
         ? contributor.properties.contributorLargeImagePath

--- a/src/components/cards/CommentCardC.tsx
+++ b/src/components/cards/CommentCardC.tsx
@@ -241,19 +241,17 @@ export const ContributorImageWrapper: React.FC<{
     salt: string;
 }> = ({ content, salt }) => {
     const contributor = getContributor(content);
-    if (contributor) {
-        const profilePic =
-            contributor.properties.contributorLargeImagePath || null;
-
-        return (
-            <ContributorImage
-                salt={salt}
-                width={146}
-                src={profilePic}
-                alt={contributor.properties.webTitle}
-            />
-        );
+    if (!contributor) {
+        return null;
     }
 
-    return null;
+    const profilePic = contributor.properties.contributorLargeImagePath || null;
+    return (
+        <ContributorImage
+            salt={salt}
+            width={146}
+            src={profilePic}
+            alt={contributor.properties.webTitle}
+        />
+    );
 };

--- a/src/components/cards/CommentCardC.tsx
+++ b/src/components/cards/CommentCardC.tsx
@@ -241,14 +241,19 @@ export const ContributorImageWrapper: React.FC<{
     salt: string;
 }> = ({ content, salt }) => {
     const contributor = getContributor(content);
-    const profilePic = contributor.properties.contributorLargeImagePath || null;
+    if (contributor) {
+        const profilePic =
+            contributor.properties.contributorLargeImagePath || null;
 
-    return (
-        <ContributorImage
-            salt={salt}
-            width={146}
-            src={profilePic}
-            alt={contributor.properties.webTitle}
-        />
-    );
+        return (
+            <ContributorImage
+                salt={salt}
+                width={146}
+                src={profilePic}
+                alt={contributor.properties.webTitle}
+            />
+        );
+    }
+
+    return null;
 };

--- a/src/fronts/opinion/variantB/components/Grid.tsx
+++ b/src/fronts/opinion/variantB/components/Grid.tsx
@@ -25,10 +25,11 @@ export const Grid: React.FC<CommentGridProps> = ({
     const rows = partition(content, 2).map((pair, i) => {
         const hasContributor = pair.find(content => {
             const contributor = getContributor(content);
-            if (contributor) {
-                return contributor.properties.contributorLargeImagePath;
+            if (!contributor) {
+                return false;
             }
-            return false;
+
+            return contributor.properties.contributorLargeImagePath;
         });
 
         const contributorLeft = (

--- a/src/fronts/opinion/variantB/components/Grid.tsx
+++ b/src/fronts/opinion/variantB/components/Grid.tsx
@@ -23,9 +23,12 @@ export const Grid: React.FC<CommentGridProps> = ({
     shouldShowGridImages
 }) => {
     const rows = partition(content, 2).map((pair, i) => {
-        const hasContributor = pair.find(c => {
-            const tag = getContributor(c);
-            return tag.properties.contributorLargeImagePath;
+        const hasContributor = pair.find(content => {
+            const contributor = getContributor(content);
+            if (contributor) {
+                return contributor.properties.contributorLargeImagePath;
+            }
+            return false;
         });
 
         const contributorLeft = (

--- a/src/fronts/opinion/variantC/components/Grid.tsx
+++ b/src/fronts/opinion/variantC/components/Grid.tsx
@@ -25,10 +25,11 @@ export const Grid: React.FC<CommentGridProps> = ({
     const rows = partition(content, 2).map((pair, i) => {
         const hasContributor = pair.find(content => {
             const contributor = getContributor(content);
-            if (contributor) {
-                return contributor.properties.contributorLargeImagePath;
+            if (!contributor) {
+                return false;
             }
-            return false;
+
+            return contributor.properties.contributorLargeImagePath;
         });
 
         const contributorLeft = (

--- a/src/fronts/opinion/variantC/components/Grid.tsx
+++ b/src/fronts/opinion/variantC/components/Grid.tsx
@@ -23,9 +23,12 @@ export const Grid: React.FC<CommentGridProps> = ({
     shouldShowGridImages
 }) => {
     const rows = partition(content, 2).map((pair, i) => {
-        const hasContributor = pair.find(c => {
-            const tag = getContributor(c);
-            return tag.properties.contributorLargeImagePath;
+        const hasContributor = pair.find(content => {
+            const contributor = getContributor(content);
+            if (contributor) {
+                return contributor.properties.contributorLargeImagePath;
+            }
+            return false;
         });
 
         const contributorLeft = (


### PR DESCRIPTION
🚨We should merge and deploy this fix before the 5pm Opinion email today 🚨

## What does this change?
Adds checks around the `getContributor()` function call in Opinion so we can handle the case where contributor is `undefined`.

## Why?
Because we assumed that a 'Contributor' tag would exist in every Opinion story - but now we've found that's not true. This fix stops an error being thrown in that scenario.