### PR TITLE
Use aws-lambda deploy type

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -2,16 +2,18 @@ stacks: [frontend]
 regions: [eu-west-1]
 
 deployments:
-    lambda:
-        type: aws-s3
-        parameters:
-            bucket: aws-frontend-editorial-emails
-            cacheControl: private
     cloudformation:
         type: cloud-formation
-        dependencies: [lambda]
         app: editorial-emails
         parameters:
             cloudFormationStackName: editorial-emails
             templatePath: cloudformation.yaml
             cloudFormationStackByTags: false
+    lambda:
+        type: aws-lambda
+        dependencies: [cloudformation]
+        parameters:
+            prefixStack: false
+            bucket: aws-frontend-editorial-emails
+            fileName: lambda.zip
+            functionNames: [frontend-editorial-emails-]

--- a/src/cdk/app.ts
+++ b/src/cdk/app.ts
@@ -47,7 +47,8 @@ export class EmailService extends cdk.Stack {
                 key
             ),
             handler: "server.handler",
-            role: s3Role
+            role: s3Role,
+            functionName: `frontend-editorial-emails-${stage.value}`
         });
 
         // tslint:disable-next-line: no-unused-expression

--- a/src/cdk/app.ts
+++ b/src/cdk/app.ts
@@ -10,27 +10,6 @@ export class EmailService extends cdk.Stack {
         super(scope, id, { env: { region: "eu-west-1" } });
 
         const frontsBucketARN = "arn:aws:s3:::aws-frontend-store/*";
-        const s3Role = new iam.Role(this, "Role", {
-            assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com")
-        });
-
-        s3Role.addToPolicy(
-            new iam.PolicyStatement({
-                effect: iam.Effect.ALLOW,
-                resources: [frontsBucketARN],
-                actions: ["s3:GetObject"]
-            })
-        );
-
-        s3Role.addToPolicy(
-            new iam.PolicyStatement({
-                effect: iam.Effect.ALLOW,
-                resources: [
-                    "arn:aws:ssm:eu-west-1:642631414762:parameter/frontend/*"
-                ],
-                actions: ["ssm:GetParameter"]
-            })
-        );
 
         const stage = new cdk.CfnParameter(this, "Stage", {
             type: "String",
@@ -47,9 +26,26 @@ export class EmailService extends cdk.Stack {
                 key
             ),
             handler: "server.handler",
-            role: s3Role,
             functionName: `frontend-editorial-emails-${stage.value}`
         });
+
+        handler.addToRolePolicy(
+            new iam.PolicyStatement({
+                effect: iam.Effect.ALLOW,
+                resources: [frontsBucketARN],
+                actions: ["s3:GetObject"]
+            })
+        );
+
+        handler.addToRolePolicy(
+            new iam.PolicyStatement({
+                effect: iam.Effect.ALLOW,
+                resources: [
+                    "arn:aws:ssm:eu-west-1:642631414762:parameter/frontend/*"
+                ],
+                actions: ["ssm:GetParameter"]
+            })
+        );
 
         // tslint:disable-next-line: no-unused-expression
         new apigateway.LambdaRestApi(this, "editorial-emails-api", {

--- a/src/cdk/app.ts
+++ b/src/cdk/app.ts
@@ -52,7 +52,11 @@ export class EmailService extends cdk.Stack {
             restApiName: `editorial-emails-${stage.value}`,
             description: "Serves editorial email fronts.",
             proxy: true,
-            handler
+            handler,
+            deployOptions: {
+                loggingLevel: apigateway.MethodLoggingLevel.INFO,
+                dataTraceEnabled: true
+            }
         });
 
         // tslint:disable-next-line: no-unused-expression


### PR DESCRIPTION
## What does this change?

This ensures the lambda actually reloads/receives the updated code.

## Why?

So deploys actually work/update things.

Previously, we updated the cloudformation and s3 zip file, but this is not enough to refresh the lambda as it needs to be prodded to reload the code.

## Link to supporting Trello card

https://trello.com/c/taC5yjWL/79-production-ready-tasks