### PR TITLE
Migrate images

### DIFF
--- a/src/Email.tsx
+++ b/src/Email.tsx
@@ -97,7 +97,7 @@ export const Email = (front: Front, salt: string, variant?: string): string => {
     const body = renderToStaticMarkup(
         <Center>
             <TableRowCell>
-                <Banner title={pageTitle} frontId={front.id} />
+                <Banner title={pageTitle} frontId={front.id} imageSalt={salt} />
                 {renderFront(front, salt, variant)}
                 <Footer title={pageTitle} frontId={front.id} />
             </TableRowCell>

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -6,7 +6,7 @@ import { formatImage } from "../image";
 export const Banner: React.FC<{
     title: string;
     frontId: string;
-    imageSalt: string;
+    imageSalt?: string;
 }> = ({ title, frontId, imageSalt }) => {
     const banners: { [key in string]: string } = {
         "email/opinion":
@@ -20,7 +20,9 @@ export const Banner: React.FC<{
     };
 
     const bannerOrigin = banners[frontId] || banners.default;
-    const bannerSrc = formatImage(bannerOrigin, imageSalt, 600);
+    const bannerSrc = imageSalt
+        ? formatImage(bannerOrigin, imageSalt, 600)
+        : bannerOrigin;
 
     return (
         <TableRowCell tdStyle={{ padding: "0" }}>

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -1,23 +1,26 @@
 import React from "react";
 import { TableRowCell } from "../layout/Table";
 import { Image } from "./Image";
+import { formatImage } from "../image";
 
-export const Banner: React.FC<{ title: string; frontId: string }> = ({
-    title,
-    frontId
-}) => {
+export const Banner: React.FC<{
+    title: string;
+    frontId: string;
+    imageSalt: string;
+}> = ({ title, frontId, imageSalt }) => {
     const banners: { [key in string]: string } = {
         "email/opinion":
-            "https://assets.guim.co.uk/images/email/banners/5ddb54b70715242bc85e071bd14f66e8/opinion.png",
+            "https://static.guim.co.uk/editorial-emails/banners/opinion.png",
         "email/media-briefing":
-            "https://assets.guim.co.uk/images/email/banners/7c27c2af5c0e7ab17516908fe012bc13/media-briefing.png",
+            "https://static.guim.co.uk/editorial-emails/banners/media-briefing.png",
         "email/sport-au":
-            "https://assets.guim.co.uk/images/email/banners/907e4c059bce8ffc82260ea5e140759f/australia-sports.png",
+            "https://static.guim.co.uk/editorial-emails/banners/australia-sports.png",
         default:
-            "https://assets.guim.co.uk/images/email/banners/0dbd7be9345b28a8678baaae474e6548/film-today.png"
+            "https://static.guim.co.uk/editorial-emails/banners/film-today.png"
     };
 
-    const bannerSrc = banners[frontId] || banners.default;
+    const bannerOrigin = banners[frontId] || banners.default;
+    const bannerSrc = formatImage(bannerOrigin, imageSalt, 600);
 
     return (
         <TableRowCell tdStyle={{ padding: "0" }}>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -9,7 +9,7 @@ const tableWrapper: TableCSS = {
     backgroundRepeat: "no-repeat",
     backgroundPosition: "bottom right",
     backgroundImage:
-        "url(https://assets.guim.co.uk/images/email/f189dff5bfa4dc66d092f57e973a51b9/grey-g.png)"
+        "url(https://static.guim.co.uk/editorial-emails/logos/grey-g.png)"
 };
 
 const tdInnerPadding: TdCSS = {

--- a/src/components/QuotationMark.tsx
+++ b/src/components/QuotationMark.tsx
@@ -19,7 +19,7 @@ const quoteIconStyle: ImageCSS = {
 // With 'culture' (i.e. 'Arts') being the fallback when no pillar available
 const getQuotationImgSrc = (pillar: Pillar, shouldUseWhite: boolean) => {
     if (shouldUseWhite) {
-        return "https://cdn.braze.eu/appboy/communication/assets/image_assets/images/5de534049ae16859519012fa/original.png?1575302148";
+        return "https://static.guim.co.uk/editorial-emails/quotes/white-quote-3x.png";
     }
 
     if (pillar && pillarProps[pillar]) {

--- a/src/utils/pillarProps.ts
+++ b/src/utils/pillarProps.ts
@@ -9,26 +9,26 @@ export const pillarProps = {
     News: {
         colour: palette.news.main,
         quote:
-            "https://assets.guim.co.uk/images/email/icons/64855e3409f4927c771a5aca921997e4/quote-news.png"
+            "https://static.guim.co.uk/editorial-emails/quotes/quote-news.png"
     },
     Opinion: {
         colour: palette.opinion.main,
         quote:
-            "https://assets.guim.co.uk/images/email/icons/cc614106682d8de187a64eb222116f3a/quote-opinion.png"
+            "https://static.guim.co.uk/editorial-emails/quotes/quote-opinion.png"
     },
     Sport: {
         colour: palette.sport.main,
         quote:
-            "https://assets.guim.co.uk/images/email/icons/b4b9407f64d0305ff1cc9a9b95524411/quote-sport.png"
+            "https://static.guim.co.uk/editorial-emails/quotes/quote-sport.png"
     },
     Arts: {
         colour: palette.culture.main,
         quote:
-            "https://assets.guim.co.uk/images/email/icons/9682728db696148fd5a6b149e556df8c/quote-culture.png"
+            "https://static.guim.co.uk/editorial-emails/quotes/quote-culture.png"
     },
     Lifestyle: {
         colour: palette.lifestyle.main,
         quote:
-            "https://assets.guim.co.uk/images/email/icons/88c54a3c173085cf29899be2d60d1480/quote-lifestyle.png"
+            "https://static.guim.co.uk/editorial-emails/quotes/quote-lifestyle.png"
     }
 };


### PR DESCRIPTION
## What does this change?

Uses new image locations.

Files live under:

https://static.guim.co.uk/editorial-emails/*

e.g.

https://static.guim.co.uk/editorial-emails/big-numbers/1.png



## Why?

So that any images in use are stored in the same s3 bucket and easy to manage/won't get accidentally deleted or changed.

## Link to supporting Trello card

https://trello.com/c/odqFLRxl/105-update-image-locations
