### PR TITLE
Adds support for Most Viewed in Film Today Z (archived)

### DIFF
--- a/src/fronts/film-today/variantZ/Collections.tsx
+++ b/src/fronts/film-today/variantZ/Collections.tsx
@@ -3,6 +3,8 @@ import { Collection as ICollection } from "../../../api";
 import { TableRowCell } from "../../../layout/Table";
 import { getDesignType } from "../../../utils/getDesignType";
 import { DefaultCollection } from "./components/DefaultCollection";
+import { MostViewedCollection } from "../../../collections/MostViewedCollection";
+import { Padding } from "../../../layout/Padding";
 
 export const Collections: React.FC<{
     frontId: string;
@@ -15,6 +17,17 @@ export const Collections: React.FC<{
 
         switch (designType) {
             case "default":
+                if (collection.collectionType === "fast") {
+                    return (
+                        <>
+                            <Padding px={12} />
+                            <MostViewedCollection
+                                collection={collection}
+                                salt={salt}
+                            />
+                        </>
+                    );
+                }
                 return (
                     <DefaultCollection collection={collection} salt={salt} />
                 );


### PR DESCRIPTION
## What does this change?
Adds support for the Most Viewed collection in Film Today Variant Z.

## Why?
Because we recently added this container to the email but never did any work to support it on this variant that we're no longer using.

## But seriously, if it's no longer used, why bother?
Because we'd rather not have any broken variants in the app if we can fix them easily.

## Screenshot
![film-today-z](https://user-images.githubusercontent.com/1692169/71174952-3e8e3a00-225e-11ea-89ca-92c68b575b1e.png)
