### PR TITLE
Free Text Images

### DIFF
--- a/src/components/FreeTextLink.tsx
+++ b/src/components/FreeTextLink.tsx
@@ -6,7 +6,7 @@ const freeTextStyles = {
     textDecoration: "underline"
 };
 
-export const TextLink: React.FC<{
+export const FreeTextLink: React.FC<{
     linkTo: string;
     linkText: string;
 }> = ({ linkTo, linkText }) => {

--- a/src/components/FreeTextLink.tsx
+++ b/src/components/FreeTextLink.tsx
@@ -10,12 +10,6 @@ export const FreeTextLink: React.FC<{
     linkTo: string;
     linkText: string;
 }> = ({ linkTo, linkText }) => {
-    // const brazeParameter = "?##braze_utm##";
-
-    // Append Braze parameter if it's a Guardian URL
-    // const isGuardianLink = linkTo.includes("theguardian.com/");
-    // const linkHref = isGuardianLink ? linkTo + brazeParameter : linkTo;
-
     return (
         <a href={linkTo} style={freeTextStyles}>
             {linkText}

--- a/src/components/TextLink.tsx
+++ b/src/components/TextLink.tsx
@@ -5,7 +5,7 @@ export const TextLink: React.FC<{
     linkTo: string;
     linkText: string;
 }> = ({ linkTo, linkText }) => {
-    const brazeParameter = "?##braze_utm##";
+    // const brazeParameter = "?##braze_utm##";
 
     // Append Braze parameter if it's a Guardian URL
     // const isGuardianLink = linkTo.includes("theguardian.com/");

--- a/src/components/cards/FreeTextCard.tsx
+++ b/src/components/cards/FreeTextCard.tsx
@@ -30,6 +30,10 @@ interface Props {
 export const FreeTextCard: React.FC<Props> = ({ content }) => {
     const { headline } = content.header;
 
+    // const testContent =
+    //     headline +
+    //     "<img src='https://i.guim.co.uk/img/media/d573f1050d94b11617204efffa6b0fe64fdf8f63/0_0_3500_2100/master/3500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=34e2c4a165177d981addc68c38485dea' alt='Alt Image' />";
+
     return (
         <TableRowCell tdStyle={outerTdStyle}>
             <TableRow>
@@ -37,7 +41,7 @@ export const FreeTextCard: React.FC<Props> = ({ content }) => {
                     <span
                         style={freeTextStyle}
                         dangerouslySetInnerHTML={{
-                            __html: getTransformedFreeText(headline)
+                            __html: getTransformedFreeText(testContent)
                         }}
                     ></span>
                 </td>

--- a/src/components/cards/FreeTextCard.tsx
+++ b/src/components/cards/FreeTextCard.tsx
@@ -13,7 +13,8 @@ const outerTdStyle: TdCSS = {
 };
 
 const innerTdStyle: TdCSS = {
-    padding: "6px 16px 12px 6px",
+    // padding: "6px 16px 12px 6px",
+    padding: "10px",
     verticalAlign: "top",
     backgroundColor: palette.neutral[100]
 };
@@ -30,10 +31,6 @@ interface Props {
 export const FreeTextCard: React.FC<Props> = ({ content }) => {
     const { headline } = content.header;
 
-    // const testContent =
-    //     headline +
-    //     "<img src='https://i.guim.co.uk/img/media/d573f1050d94b11617204efffa6b0fe64fdf8f63/0_0_3500_2100/master/3500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=34e2c4a165177d981addc68c38485dea' alt='Alt Image' />";
-
     return (
         <TableRowCell tdStyle={outerTdStyle}>
             <TableRow>
@@ -41,7 +38,7 @@ export const FreeTextCard: React.FC<Props> = ({ content }) => {
                     <span
                         style={freeTextStyle}
                         dangerouslySetInnerHTML={{
-                            __html: getTransformedFreeText(testContent)
+                            __html: getTransformedFreeText(headline)
                         }}
                     ></span>
                 </td>

--- a/src/components/cards/FreeTextCard.tsx
+++ b/src/components/cards/FreeTextCard.tsx
@@ -13,7 +13,6 @@ const outerTdStyle: TdCSS = {
 };
 
 const innerTdStyle: TdCSS = {
-    // padding: "6px 16px 12px 6px",
     padding: "10px",
     verticalAlign: "top",
     backgroundColor: palette.neutral[100]

--- a/src/utils/getTransformedFreeText.tsx
+++ b/src/utils/getTransformedFreeText.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import ReactHtmlParser from "react-html-parser";
-import { TextLink } from "../components/TextLink";
+import { FreeTextLink } from "../components/FreeTextLink";
+import { Image } from "../components/Image";
 
 export const getTransformedFreeText = (freeText: string): string => {
     if (!freeText) return "";
@@ -16,6 +17,13 @@ const transform = (node: any): React.ReactElement | null => {
     if (node.type === "tag" && node.name === "a" && node.attribs.href) {
         const linkTo = node.attribs.href;
         const linkText = node.children[0].data;
-        return <TextLink linkTo={linkTo} linkText={linkText} />;
+        if (linkText) {
+            return <FreeTextLink linkTo={linkTo} linkText={linkText} />;
+        }
+    }
+
+    if (node.type === "tag" && node.name === "img" && node.attribs.src) {
+        const { src, alt } = node.attribs;
+        return <Image src={src} alt={alt || ""} width={560} />;
     }
 };

--- a/src/utils/getTransformedFreeText.tsx
+++ b/src/utils/getTransformedFreeText.tsx
@@ -15,8 +15,11 @@ export const getTransformedFreeText = (freeText: string): string => {
 
 const transform = (node: any): React.ReactElement | null => {
     if (node.type === "tag" && node.name === "a" && node.attribs.href) {
+        // Only replace <a> tag with FreeTextLink if we can successfully
+        // read the link text from inside the <a> tag
         const linkTo = node.attribs.href;
-        const linkText = node.children[0].data;
+        const linkText =
+            node.children && node.children[0] ? node.children[0].data : null;
         if (linkText) {
             return <FreeTextLink linkTo={linkTo} linkText={linkText} />;
         }


### PR DESCRIPTION
## What does this change?
Adds support for images inside a Free Text container.

## Why?
Editors can't currently add images, but we should ensure our app doesn't break if ones comes through in the free text. 🤷‍♂️

## Screenshot
![Screenshot 2019-12-19 at 17 08 01](https://user-images.githubusercontent.com/1692169/71193500-24665300-2282-11ea-873a-3be35bd64e14.png)

