### PR TITLE
(almost) Create the Domain name with the CDK stack

### DIFF
--- a/src/cdk/app.ts
+++ b/src/cdk/app.ts
@@ -4,22 +4,55 @@ import lambda = require("@aws-cdk/aws-lambda");
 import iam = require("@aws-cdk/aws-iam");
 import route53 = require("@aws-cdk/aws-route53");
 import s3 = require("@aws-cdk/aws-s3");
-import * as acm from "@aws-cdk/aws-certificatemanager";
+import {Certificate} from "@aws-cdk/aws-certificatemanager";
 import {CfnMapping, CfnOutput, CfnParameter, Fn} from "@aws-cdk/core";
-import {DomainName} from "@aws-cdk/aws-apigateway";
+
 
 export class EmailService extends cdk.Stack {
 
     constructor(scope: cdk.Construct, id: string) {
         super(scope, id, { env: { region: "eu-west-1" } });
 
-        const frontsBucketARN = "arn:aws:s3:::aws-frontend-store/*";
-
         const stage = new cdk.CfnParameter(this, "Stage", {
             type: "String",
             default: "CODE"
         });
 
+        const handler = this.createHandler(stage);
+
+        const api = new apigateway.LambdaRestApi(this, "editorial-emails-api", {
+            restApiName: `editorial-emails-${stage.value}`,
+            description: "Serves editorial email fronts.",
+            proxy: true,
+            handler,
+            deployOptions: {
+                loggingLevel: apigateway.MethodLoggingLevel.INFO,
+                dataTraceEnabled: true
+            }
+        });
+
+        const apiDomainName = this.createDomainName(api, stage);
+
+        // tslint:disable-next-line: no-unused-expression
+        new route53.CfnHealthCheck(this, "editorial-emails-healthcheck", {
+            healthCheckConfig: {
+                type: "HTTPS",
+                fullyQualifiedDomainName: apiDomainName.domainName,
+                resourcePath: "/healthcheck",
+                port: 443,
+                failureThreshold: 3
+            }
+        });
+
+        // tslint:disable-next-line: no-unused-expression
+        new CfnOutput(this, `editorial-emails-hostname`, {
+            description: "hostname",
+            value: `${apiDomainName.domainNameAliasDomainName}`,
+        });
+    }
+
+    createHandler(stage: CfnParameter): lambda.Function {
+        const frontsBucketARN = "arn:aws:s3:::aws-frontend-store/*";
         const bucket = "aws-frontend-editorial-emails";
         const key = `frontend/${stage.value}/lambda/lambda.zip`;
 
@@ -45,47 +78,19 @@ export class EmailService extends cdk.Stack {
             new iam.PolicyStatement({
                 effect: iam.Effect.ALLOW,
                 resources: [
-                    "arn:aws:ssm:eu-west-1:642631414762:parameter/frontend/*"
+                    `arn:aws:ssm:${this.region}:${this.account}:parameter/frontend/*`
                 ],
                 actions: ["ssm:GetParameter"]
             })
         );
 
-        const api = new apigateway.LambdaRestApi(this, "editorial-emails-api", {
-            restApiName: `editorial-emails-${stage.value}`,
-            description: "Serves editorial email fronts.",
-            proxy: true,
-            handler,
-            deployOptions: {
-                loggingLevel: apigateway.MethodLoggingLevel.INFO,
-                dataTraceEnabled: true
-            }
-        });
-
-        const apiDomainName = this.createDomainName(stage);
-        apiDomainName.addBasePathMapping(api, { basePath: "" });
-
-        // tslint:disable-next-line: no-unused-expression
-        new route53.CfnHealthCheck(this, "editorial-emails-healthcheck", {
-            healthCheckConfig: {
-                type: "HTTPS",
-                fullyQualifiedDomainName: "email-newsletters.theguardian.com",
-                resourcePath: "/healthcheck",
-                port: 443,
-                failureThreshold: 3
-            }
-        });
-
-        // tslint:disable-next-line: no-unused-expression
-        new CfnOutput(this, `editorial-emails-hostname`, {
-            description: "hostname",
-            value: `${apiDomainName.domainNameAliasDomainName}`,
-        });
+        return handler;
     }
 
-    private createDomainName(stage: CfnParameter): DomainName {
+    createDomainName(api: apigateway.LambdaRestApi, stage: CfnParameter): apigateway.DomainName {
         const mappingKey = "mapping";
         const domainNameKey = "DomainName";
+        const certificateIdKey = "CertificateId";
 
         // tslint:disable-next-line: no-unused-expression
         new CfnMapping(this, mappingKey, {
@@ -93,22 +98,28 @@ export class EmailService extends cdk.Stack {
                 [domainNameKey]: {
                     CODE: "email-newsletters.code.dev-theguardian.com",
                     PROD: "email-newsletters.theguardian.com"
+                },
+                [certificateIdKey]: {
+                    CODE: 'e9353a7b-d4b6-4069-b7f6-e6bccbfc69bb',
+                    PROD: '6462b5b8-ee19-4397-8481-0fbd3151c7a3'
                 }
             }
         });
 
         const domainName = Fn.findInMap(mappingKey, domainNameKey, stage.valueAsString);
+        const certificateArn = `arn:aws:acm:us-east-1:${this.account}:certificate/${Fn.findInMap(mappingKey, certificateIdKey, stage.valueAsString)}`;
 
-        const apiCertificate = new acm.Certificate(this, "editorial-emails-api-certificate", {
-            domainName,
-            validationMethod: acm.ValidationMethod.DNS
-        });
+        const certificate = Certificate.fromCertificateArn(this, "editorial-emails-api-certificate",certificateArn);
 
-        return new apigateway.DomainName(this, "editorial-emails-api-domain-name", {
+        const apiDomainName = new apigateway.DomainName(this, "editorial-emails-api-domain-name", {
             domainName,
-            certificate: apiCertificate,
+            certificate,
             endpointType: apigateway.EndpointType.EDGE,
         });
+
+        apiDomainName.addBasePathMapping(api, { basePath: "" });
+
+        return apiDomainName
     }
 }
 


### PR DESCRIPTION
## What does this change?

This adds the creation of (almost) all the necessary components to put an API gateway behind a custom domain name. I suspect these configurations had been done manually in the previous incarnations of the project as I don't recall CDK supporting all these constructs last year.

Missing from that CDK template is the actual CNAME DNS record creation, which can't be automated as it is created outside of AWS' remit, and requires a message to our DNS team.

## Why?
This allows for an easier creation of a new environment, or re-deploying the app if we were to delete the stack again.

## Link to supporting Trello card
n/a

## Once merged
- [ ] Deploy to prod
- [ ] Redeploy to code for good measure
- [ ] Get the DNS name of the cloudfront services that have been created, and output (see `CfnOutput`)
- [ ] Ask the DNS team to CNAME to these services to have fancy new domain names
